### PR TITLE
WinDev Helper v2.8.0 - updates for winapp CLI v0.3.0

### DIFF
--- a/.github/skills/winapp-cli/SKILL.md
+++ b/.github/skills/winapp-cli/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: winapp-cli
-description: 'Windows App Development CLI (winapp) for building, packaging, and deploying Windows applications. Use when asked to initialize Windows app projects, create MSIX packages, generate AppxManifest.xml, manage development certificates, add package identity for debugging, sign packages, publish to Microsoft Store, or access Windows SDK build tools. Supports .NET, C++, Electron, Rust, Tauri, and cross-platform frameworks targeting Windows.'
+description: 'Windows App Development CLI (winapp) for building, packaging, running, and deploying Windows applications. Use when asked to initialize Windows app projects, create MSIX packages, run packaged apps, generate AppxManifest.xml, manage development certificates, add package identity for debugging, sign packages, publish to Microsoft Store, automate UI testing, or access Windows SDK build tools. Supports .NET, C++, Electron, Rust, Tauri, and cross-platform frameworks targeting Windows.'
 license: MIT
-version: '0.2.1'
+version: '0.3.0'
 ---
 
 # Windows App Development CLI (winapp)
@@ -25,6 +25,10 @@ Use this skill when you need to:
 - Access Windows APIs that require package identity (notifications, Windows AI, shell integration)
 - Publish applications to the Microsoft Store (via `winapp store` subcommand)
 - Create external catalogs for asset management
+- Run apps as packaged apps from a build output folder (`winapp run`)
+- Automate UI testing and interaction with running apps (`winapp ui`)
+- Add app execution aliases to manifests
+- Enable `dotnet run` support for packaged .NET apps
 
 ## Prerequisites
 
@@ -58,6 +62,8 @@ winapp init [<base-directory>] [options]
 > **v0.2.0 Breaking Change:** `init` no longer generates a certificate automatically. Run `winapp cert generate` explicitly when you need a dev signing certificate. The `--no-cert` flag has been removed.
 >
 > **v0.2.0 .NET Projects:** When `winapp init` detects a `.csproj`, it configures NuGet packages in the project file directly instead of creating a `winapp.yaml`. This is the expected behavior for .NET projects.
+
+> **v0.3.0 .NET Projects:** `winapp init` now also sets up the `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet package, enabling `dotnet run` support for packaged apps.
 
 **Example:**
 
@@ -420,6 +426,135 @@ winapp create-external-catalog
 winapp create-external-catalog ./catalogs
 ```
 
+### run - Run Packaged App (v0.3.0+)
+
+Pack a folder and run it as a packaged app. Registers a loose package, launches the app, and preserves `LocalState` across re-deploys.
+
+```bash
+winapp run <input-folder> [options]
+```
+
+**Options:**
+
+| Option | Description |
+| ------ | ----------- |
+| `--manifest <path>` | Path to the AppxManifest.xml |
+| `--detach` | Launch and return control immediately |
+| `--unregister-on-exit` | Clean up registered package when app closes |
+| `--debug-output` | Capture OutputDebugString and crash dumps |
+| `--symbols` | Download PDBs from Microsoft Symbol Server |
+
+**Examples:**
+
+```bash
+# Run a built app as packaged
+winapp run ./bin/Debug
+
+# Run with custom manifest
+winapp run ./bin/Debug --manifest ./Package.appxmanifest
+
+# Run detached (for CI/automation)
+winapp run ./bin/Debug --detach --unregister-on-exit
+
+# Run with debug output and symbol resolution
+winapp run ./bin/Debug --debug-output --symbols
+```
+
+### unregister - Remove Dev Package (v0.3.0+)
+
+Cleanup counterpart to `winapp run`. Safely removes a sideloaded dev package.
+
+```bash
+winapp unregister [<package-name>]
+```
+
+**Example:**
+
+```bash
+# Unregister the dev package
+winapp unregister
+```
+
+### manifest add-alias - Add Execution Alias (v0.3.0+)
+
+Adds a `uap5:AppExecutionAlias` to the manifest so a packaged app can be launched by name from the command line.
+
+```bash
+winapp manifest add-alias <alias> [--manifest <path>]
+```
+
+**Example:**
+
+```bash
+# Add an alias so the app can be launched as "myapp" from terminal
+winapp manifest add-alias myapp
+```
+
+> **v0.3.0 Note:** `winapp init` and `winapp manifest generate` now create `Package.appxmanifest` (matching the Visual Studio convention) instead of `appxmanifest.xml`.
+
+### ui - UI Automation (v0.3.0+)
+
+UI Automation built into the CLI. Inspect and interact with any running Windows application.
+
+```bash
+winapp ui <subcommand> [options]
+```
+
+**Subcommands:**
+
+| Subcommand | Description |
+| ---------- | ----------- |
+| `list-windows` | List all visible top-level windows |
+| `inspect` | Walk the full UI Automation tree of a window |
+| `search` | Find elements by name, type, or automation ID |
+| `click` | Click an element by automation ID |
+| `set-value` | Set a value on an element (e.g., TextBox) |
+| `screenshot` | Capture a window screenshot |
+| `wait-for` | Block until a specific element appears |
+
+**Common Options:**
+
+| Option | Description |
+| ------ | ----------- |
+| `-a, --app <name>` | Target app name |
+| `-i` | Interactive mode (for inspect) |
+| `-o, --output <path>` | Output file path (for screenshot) |
+| `-t, --timeout <ms>` | Timeout in milliseconds (for wait-for) |
+
+**Examples:**
+
+```bash
+# List all visible windows
+winapp ui list-windows
+
+# Inspect UI tree of a specific app
+winapp ui inspect -a "My App" -i
+
+# Click a button by automation ID
+winapp ui click "btn-save-d1" -a "My App"
+
+# Take a screenshot
+winapp ui screenshot -a "My App" -o screenshot.png
+
+# Set a TextBox value
+winapp ui set-value "txt-name-a3" "Hello" -a "My App"
+
+# Wait for an element to appear
+winapp ui wait-for "Done" -a "My App" -t 10000
+```
+
+### complete - Shell Completion (v0.3.0+)
+
+Set up tab completion for all winapp commands.
+
+```bash
+# PowerShell (permanent)
+winapp complete --setup powershell >> $PROFILE
+
+# PowerShell (current session)
+winapp complete --setup powershell | Out-String | Invoke-Expression
+```
+
 ## Common Workflows
 
 ### Workflow 1: Initialize New Windows App Project
@@ -527,6 +662,43 @@ winapp store publish ./my-app --packageRolloutPercentage 10
 winapp store publish ./my-app --noCommit
 ```
 
+### Workflow 7: Run and Test Packaged App (v0.3.0+)
+
+```bash
+# 1. Build your app
+dotnet build
+
+# 2. Run as packaged app
+winapp run ./bin/Debug/net10.0-windows10.0.26100.0/win-x64
+
+# 3. Or use dotnet run (with Microsoft.Windows.SDK.BuildTools.WinApp NuGet package)
+dotnet run
+
+# 4. Clean up when done
+winapp unregister
+```
+
+### Workflow 8: UI Automation Testing (v0.3.0+)
+
+```bash
+# 1. Build and run the app
+winapp run ./bin/Debug --detach
+
+# 2. Wait for the app to be ready
+winapp ui wait-for "MainWindow" -a "My App" -t 10000
+
+# 3. Interact with UI elements
+winapp ui set-value "txt-name" "Test User" -a "My App"
+winapp ui click "btn-submit" -a "My App"
+
+# 4. Verify results
+winapp ui search "Success" -a "My App"
+winapp ui screenshot -a "My App" -o result.png
+
+# 5. Clean up
+winapp unregister
+```
+
 ## Windows APIs Enabled by Package Identity
 
 Package identity unlocks access to powerful Windows APIs:
@@ -556,6 +728,8 @@ Package identity unlocks access to powerful Windows APIs:
 | No certificate after init (v0.2.0+) | Run `winapp cert generate` explicitly - init no longer auto-generates certs |
 | Missing winapp.yaml for .NET (v0.2.0+) | This is expected - .NET projects configure packages in .csproj directly |
 | Store publish fails | Run `winapp store reconfigure` to verify credentials are set |
+| UI automation can't find window | Use `winapp ui list-windows` to verify app name; try with quotes for names with spaces |
+| `dotnet run` doesn't launch packaged | Install `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet package or run `winapp init` |
 
 ## Framework-Specific Guides
 
@@ -576,3 +750,6 @@ Package identity unlocks access to powerful Windows APIs:
 - [MSIX Packaging Overview](https://learn.microsoft.com/windows/msix/overview)
 - [Microsoft Store Developer CLI](https://learn.microsoft.com/windows/apps/publish/msstore-dev-cli/commands)
 - [Package Identity Overview](https://learn.microsoft.com/windows/apps/desktop/modernize/package-identity-overview)
+- [UI Automation Getting Started](https://github.com/microsoft/WinAppCli/blob/main/docs/ui-automation.md)
+- [dotnet run Support](https://github.com/microsoft/WinAppCli/blob/main/docs/dotnet-run-support.md)
+- [Shell Completion Guide](https://github.com/microsoft/WinAppCli/blob/main/docs/guides/shell-completion.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the WinDev Helper extension will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-04-22
+
+> ⚠️ The preview pane and properties panel features are currently in preview. Please report any bugs or suggestions to our GitHub issues.
+
+### Added
+
+- **Run as Packaged App** (winapp CLI v0.3.0)
+  - New **WinDev: Run as Packaged App** command to launch apps as packaged apps from a build output folder
+  - Supports detached mode, debug output with crash dumps, and automatic unregister on exit
+  - Equivalent to Visual Studio's F5 experience for packaged apps
+
+- **Unregister Dev Package** (winapp CLI v0.3.0)
+  - New **WinDev: Unregister Dev Package** command to clean up sideloaded dev packages
+
+- **UI Automation** (winapp CLI v0.3.0)
+  - New **WinDev: UI: List Windows** command to enumerate visible app windows
+  - New **WinDev: UI: Inspect App** command to walk the UI Automation tree of a running app
+  - New **WinDev: UI: Take Screenshot** command to capture app window screenshots
+  - Enables agentic and automated testing workflows
+
+- **Add App Execution Alias** (winapp CLI v0.3.0)
+  - New **WinDev: Add App Execution Alias** command to add `uap5:AppExecutionAlias` to manifests
+  - Allows launching packaged apps by name from the command line
+
+### Changed
+
+- **Updated for winapp CLI v0.3.0**
+  - `winapp init` and `winapp manifest generate` now create `Package.appxmanifest` (VS convention) instead of `appxmanifest.xml`
+  - .NET projects initialized with `winapp init` now include `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet package for `dotnet run` support
+  - `get-winapp-path` gracefully falls back to global cache when local cache is missing
+
 ## [2.7.0] - 2026-03-31
 
 > ⚠️ The preview pane and properties panel features are currently in preview. Please report any bugs or suggestions to our GitHub issues.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,19 @@ On non-Windows platforms, the extension provides an HTML-based preview renderer 
 - View certificate details (subject, issuer, validity)
 - Install certificates for testing
 - Create debug identities for your apps
+- **Run as packaged app** - Launch apps as packaged apps from build output
+- **Unregister dev packages** - Clean up sideloaded packages
+- **Add app execution aliases** - Launch packaged apps by name from the terminal
 - **Microsoft Store publishing** - Publish directly to the Microsoft Store from VS Code
 - Check submission status and manage Store apps
 - Create external catalogs for asset management
+
+### 🧪 UI Automation
+
+- **List windows** - Enumerate visible app windows
+- **Inspect UI trees** - Walk the UI Automation tree of any running Windows app
+- **Take screenshots** - Capture app window screenshots
+- Enables automated testing and agentic workflows via `winapp ui`
 
 ### 📝 Project & Item Templates
 
@@ -188,6 +198,12 @@ dotnet new winuilib -n MyLib
 | `WinUI: Select Target Platform` | Switch x86/x64/ARM64 |
 | `WinUI: Install WinUI Templates` | Install dotnet templates |
 | `WinUI: Check WinApp CLI Installation` | Verify CLI is installed |
+| `WinDev: Run as Packaged App` | Launch app as a packaged app |
+| `WinDev: Unregister Dev Package` | Remove a sideloaded dev package |
+| `WinDev: Add App Execution Alias` | Add launch alias to manifest |
+| `WinDev: UI: List Windows` | List visible app windows |
+| `WinDev: UI: Inspect App` | Inspect UI Automation tree |
+| `WinDev: UI: Take Screenshot` | Capture app window screenshot |
 
 ## Extension Settings
 
@@ -241,6 +257,14 @@ This extension integrates with the **Windows App Development CLI (winapp)**, whi
 
 - `winapp tool` - Access Windows SDK tools
 - `winapp get-winapp-path` - Get paths to installed SDK components
+
+### Run & Automation (v0.3.0+)
+
+- `winapp run` - Run a build output as a packaged app
+- `winapp unregister` - Remove a sideloaded dev package
+- `winapp manifest add-alias` - Add an app execution alias to the manifest
+- `winapp ui` - UI Automation: list windows, inspect trees, click, screenshot, and more
+- `winapp complete` - Set up shell tab completion
 
 Learn more at [github.com/microsoft/WinAppCli](https://github.com/microsoft/WinAppCli).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the WinDev Helper extension documentation. This folder contains detailed guides and reference materials for using the extension.
 
-> ⚠️ **Preview Release**: Documentation for version 2.7 includes experimental features like native XAML preview and XAML properties pane.
+> ⚠️ **Preview Release**: Documentation for version 2.8 includes experimental features like native XAML preview and XAML properties pane.
 
 ## Contents
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -452,7 +452,7 @@ Launches an application as a packaged app from a build output folder. Prompts fo
 
 **Command ID:** `windev-helper.unregisterPackage`
 
-Removes a sideloaded dev package registered by `winapp run`. Prompts for an optional package name.
+Removes a sideloaded dev package registered by `winapp run`. Runs in the context of the current project. Prompts for an optional package name (leave empty to let the CLI discover it).
 
 **Uses:** `winapp unregister` CLI command
 
@@ -467,7 +467,8 @@ Adds a `uap5:AppExecutionAlias` to the manifest so a packaged app can be launche
 **Usage:**
 
 1. Enter the alias name (e.g., "myapp")
-2. The alias is added to the manifest
+2. The manifest is automatically discovered from the current project
+3. The alias is added to the manifest
 
 **Uses:** `winapp manifest add-alias` CLI command (v0.3.0+)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -430,6 +430,79 @@ Creates an external catalog for streamlined asset management across applications
 
 ---
 
+## Run & Automation Commands
+
+These commands provide packaged app launch and UI automation capabilities. They require winapp CLI v0.3.0 or later.
+
+### WinDev: Run as Packaged App
+
+**Command ID:** `windev-helper.runPackagedApp`
+
+Launches an application as a packaged app from a build output folder. Prompts for:
+
+1. Build output folder containing your compiled app
+2. Run mode: normal, detached, or with debug output
+3. Whether to unregister the package on exit
+
+**Uses:** `winapp run` CLI command
+
+---
+
+### WinDev: Unregister Dev Package
+
+**Command ID:** `windev-helper.unregisterPackage`
+
+Removes a sideloaded dev package registered by `winapp run`. Prompts for an optional package name.
+
+**Uses:** `winapp unregister` CLI command
+
+---
+
+### WinDev: Add App Execution Alias
+
+**Command ID:** `windev-helper.manifestAddAlias`
+
+Adds a `uap5:AppExecutionAlias` to the manifest so a packaged app can be launched by name from the command line.
+
+**Usage:**
+
+1. Enter the alias name (e.g., "myapp")
+2. The alias is added to the manifest
+
+**Uses:** `winapp manifest add-alias` CLI command (v0.3.0+)
+
+---
+
+### WinDev: UI: List Windows
+
+**Command ID:** `windev-helper.uiListWindows`
+
+Lists all visible top-level windows. Optionally filter by app name. Results appear in the WinUI Packaging output channel.
+
+**Uses:** `winapp ui list-windows` CLI command
+
+---
+
+### WinDev: UI: Inspect App
+
+**Command ID:** `windev-helper.uiInspect`
+
+Walks the full UI Automation tree of a running app. Prompts for the app name.
+
+**Uses:** `winapp ui inspect` CLI command
+
+---
+
+### WinDev: UI: Take Screenshot
+
+**Command ID:** `windev-helper.uiScreenshot`
+
+Captures a screenshot of an app window. Prompts for the app name and output file location.
+
+**Uses:** `winapp ui screenshot` CLI command
+
+---
+
 ### WinUI: Generate App Manifest
 
 **Command ID:** `windev-helper.generateManifest`

--- a/docs/winapp-cli.md
+++ b/docs/winapp-cli.md
@@ -2,7 +2,7 @@
 
 This document provides a comprehensive guide to using the Windows App Development CLI (winapp) with the WinDev Helper extension.
 
-> **Note:** This guide covers winapp CLI v0.2.1 and later. See the [Breaking Changes](#breaking-changes-v020) section for migration notes.
+> **Note:** This guide covers winapp CLI v0.3.0 and later. See the [Breaking Changes](#breaking-changes-v020) section for migration notes.
 
 ## Overview
 
@@ -16,6 +16,11 @@ The Windows App Development CLI (winapp) is a command-line tool that simplifies 
 - Debug identity creation
 - **Microsoft Store publishing** (v0.2.0+)
 - **External catalog management** (v0.2.0+)
+- **Run packaged apps** from build output (v0.3.0+)
+- **UI Automation** — inspect, interact with, and screenshot running apps (v0.3.0+)
+- **App execution aliases** — launch packaged apps by name (v0.3.0+)
+- **Shell completion** for all commands (v0.3.0+)
+- **`dotnet run` support** for packaged .NET apps (v0.3.0+)
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windev-helper",
-  "version": "2.5.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windev-helper",
-      "version": "2.5.0",
+      "version": "2.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -14,7 +14,7 @@
         "@types/vscode": "^1.108.1",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.5.2",
-        "@vscode/vsce": "^3.2.2",
+        "@vscode/vsce": "^3.9.1",
         "esbuild": "^0.27.2",
         "eslint": "^9.39.2",
         "npm-run-all": "^4.1.5",
@@ -1723,9 +1723,9 @@
       }
     },
     "node_modules/@vscode/vsce": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
-      "integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.1.tgz",
+      "integrity": "sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1756,7 +1756,7 @@
         "typed-rest-client": "^1.8.4",
         "url-join": "^4.0.1",
         "xml2js": "^0.5.0",
-        "yauzl": "^2.3.1",
+        "yauzl": "^3.2.1",
         "yazl": "^2.2.2"
       },
       "bin": {
@@ -3772,16 +3772,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -8803,14 +8793,17 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yazl": {

--- a/package.json
+++ b/package.json
@@ -313,6 +313,20 @@
           "group": "winui@4"
         }
       ],
+      "view/title": [
+        {
+          "command": "windevHelper.propertyPane.refresh",
+          "when": "view == windevHelper.propertyPane",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "windevHelper.propertyPane.copyValue",
+          "when": "view == windevHelper.propertyPane",
+          "group": "inline"
+        }
+      ],
       "csharp.solutionExplorer.context": [
         {
           "command": "windev-helper.addPage",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "windev-helper",
   "displayName": "WinDev Helper",
   "description": "Build beautiful, performant WinUI apps with VS Code. Debug, build, package, and deploy Windows apps powered by the Windows App SDK.",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "publisher": "alvinashcraft",
   "preview": true,
   "icon": "images/icon.png",
@@ -202,6 +202,36 @@
       {
         "command": "windev-helper.createExternalCatalog",
         "title": "Create External Catalog",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.runPackagedApp",
+        "title": "Run as Packaged App",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.unregisterPackage",
+        "title": "Unregister Dev Package",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.manifestAddAlias",
+        "title": "Add App Execution Alias",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.uiListWindows",
+        "title": "UI: List Windows",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.uiInspect",
+        "title": "UI: Inspect App",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.uiScreenshot",
+        "title": "UI: Take Screenshot",
         "category": "WinDev"
       },
       {

--- a/package.json
+++ b/package.json
@@ -291,32 +291,84 @@
       ]
     },
     "menus": {
-      "view/title": [
+      "explorer/context": [
         {
-          "command": "windevHelper.propertyPane.refresh",
-          "when": "view == windevHelper.propertyPane",
-          "group": "navigation"
+          "command": "windev-helper.addPage",
+          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
+          "group": "winui@1"
         },
         {
-          "command": "windevHelper.propertyPane.toggleGrouping",
-          "when": "view == windevHelper.propertyPane",
-          "group": "navigation"
+          "command": "windev-helper.addUserControl",
+          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
+          "group": "winui@2"
         },
         {
-          "command": "windevHelper.propertyPane.toggleDefaults",
-          "when": "view == windevHelper.propertyPane",
-          "group": "navigation"
+          "command": "windev-helper.addWindow",
+          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
+          "group": "winui@3"
+        },
+        {
+          "command": "windev-helper.addViewModel",
+          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
+          "group": "winui@4"
         }
       ],
-      "view/item/context": [
+      "csharp.solutionExplorer.context": [
         {
-          "command": "windevHelper.propertyPane.copyValue",
-          "when": "view == windevHelper.propertyPane && viewItem == property || viewItem == boundProperty",
-          "group": "inline"
+          "command": "windev-helper.addPage",
+          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
+          "group": "winui@1"
         },
         {
-          "command": "windevHelper.propertyPane.goToDefinition",
-          "when": "view == windevHelper.propertyPane && viewItem == property || viewItem == boundProperty",
+          "command": "windev-helper.addUserControl",
+          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
+          "group": "winui@2"
+        },
+        {
+          "command": "windev-helper.addWindow",
+          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
+          "group": "winui@3"
+        },
+        {
+          "command": "windev-helper.addViewModel",
+          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
+          "group": "winui@4"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "windev-helper.buildProject",
+          "when": "windevHelper.isWinUIProject"
+        },
+        {
+          "command": "windev-helper.rebuildProject",
+          "when": "windevHelper.isWinUIProject"
+        },
+        {
+          "command": "windev-helper.cleanProject",
+          "when": "windevHelper.isWinUIProject"
+        },
+        {
+          "command": "windev-helper.debugProject",
+          "when": "windevHelper.isWinUIProject"
+        },
+        {
+          "command": "windev-helper.runWithoutDebugging",
+          "when": "windevHelper.isWinUIProject"
+        },
+        {
+          "command": "windev-helper.createMsixPackage",
+          "when": "windevHelper.isWinUIProject"
+        },
+        {
+          "command": "windev-helper.openXamlPreview",
+          "when": "resourceExtname == .xaml || editorLangId == xaml"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "windev-helper.openXamlPreview",
+          "when": "resourceExtname == .xaml || editorLangId == xaml",
           "group": "navigation"
         }
       ]
@@ -399,89 +451,6 @@
           "description": "Theme for XAML preview. 'auto' follows VS Code theme or project's App.xaml RequestedTheme."
         }
       }
-    },
-    "menus": {
-      "explorer/context": [
-        {
-          "command": "windev-helper.addPage",
-          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
-          "group": "winui@1"
-        },
-        {
-          "command": "windev-helper.addUserControl",
-          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
-          "group": "winui@2"
-        },
-        {
-          "command": "windev-helper.addWindow",
-          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
-          "group": "winui@3"
-        },
-        {
-          "command": "windev-helper.addViewModel",
-          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
-          "group": "winui@4"
-        }
-      ],
-      "csharp.solutionExplorer.context": [
-        {
-          "command": "windev-helper.addPage",
-          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
-          "group": "winui@1"
-        },
-        {
-          "command": "windev-helper.addUserControl",
-          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
-          "group": "winui@2"
-        },
-        {
-          "command": "windev-helper.addWindow",
-          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
-          "group": "winui@3"
-        },
-        {
-          "command": "windev-helper.addViewModel",
-          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
-          "group": "winui@4"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "windev-helper.buildProject",
-          "when": "windevHelper.isWinUIProject"
-        },
-        {
-          "command": "windev-helper.rebuildProject",
-          "when": "windevHelper.isWinUIProject"
-        },
-        {
-          "command": "windev-helper.cleanProject",
-          "when": "windevHelper.isWinUIProject"
-        },
-        {
-          "command": "windev-helper.debugProject",
-          "when": "windevHelper.isWinUIProject"
-        },
-        {
-          "command": "windev-helper.runWithoutDebugging",
-          "when": "windevHelper.isWinUIProject"
-        },
-        {
-          "command": "windev-helper.createMsixPackage",
-          "when": "windevHelper.isWinUIProject"
-        },
-        {
-          "command": "windev-helper.openXamlPreview",
-          "when": "resourceExtname == .xaml || editorLangId == xaml"
-        }
-      ],
-      "editor/title": [
-        {
-          "command": "windev-helper.openXamlPreview",
-          "when": "resourceExtname == .xaml || editorLangId == xaml",
-          "group": "navigation"
-        }
-      ]
     },
     "keybindings": [
       {
@@ -616,16 +585,16 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.108.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
-    "@vscode/vsce": "^3.2.2",
-    "typescript-eslint": "^8.52.0",
-    "eslint": "^9.39.2",
+    "@types/vscode": "^1.108.1",
+    "@vscode/test-cli": "^0.0.12",
+    "@vscode/test-electron": "^2.5.2",
+    "@vscode/vsce": "^3.9.1",
     "esbuild": "^0.27.2",
+    "eslint": "^9.39.2",
     "npm-run-all": "^4.1.5",
     "typescript": "^5.9.3",
-    "@vscode/test-cli": "^0.0.12",
-    "@vscode/test-electron": "^2.5.2"
+    "typescript-eslint": "^8.52.0"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,14 @@ export const COMMANDS = {
     CREATE_EXTERNAL_CATALOG: 'windev-helper.createExternalCatalog',
     // Certificate info command (v0.2.1+)
     CERTIFICATE_INFO: 'windev-helper.certificateInfo',
+    // Run & manage commands (v0.3.0+)
+    RUN_PACKAGED_APP: 'windev-helper.runPackagedApp',
+    UNREGISTER_PACKAGE: 'windev-helper.unregisterPackage',
+    MANIFEST_ADD_ALIAS: 'windev-helper.manifestAddAlias',
+    // UI Automation commands (v0.3.0+)
+    UI_LIST_WINDOWS: 'windev-helper.uiListWindows',
+    UI_INSPECT: 'windev-helper.uiInspect',
+    UI_SCREENSHOT: 'windev-helper.uiScreenshot',
 } as const;
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -304,6 +304,44 @@ function registerCommands(context: vscode.ExtensionContext): void {
         })
     );
 
+    // Run & manage commands (v0.3.0+)
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.RUN_PACKAGED_APP, async () => {
+            await services.packageManager.runPackagedApp(services.projectManager.currentProject);
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.UNREGISTER_PACKAGE, async () => {
+            await services.packageManager.unregisterPackage();
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.MANIFEST_ADD_ALIAS, async () => {
+            await services.packageManager.addManifestAlias();
+        })
+    );
+
+    // UI Automation commands (v0.3.0+)
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.UI_LIST_WINDOWS, async () => {
+            await services.packageManager.uiListWindows();
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.UI_INSPECT, async () => {
+            await services.packageManager.uiInspect();
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.UI_SCREENSHOT, async () => {
+            await services.packageManager.uiScreenshot();
+        })
+    );
+
     // XAML Preview command
     context.subscriptions.push(
         vscode.commands.registerCommand(COMMANDS.OPEN_XAML_PREVIEW, async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -313,13 +313,13 @@ function registerCommands(context: vscode.ExtensionContext): void {
 
     context.subscriptions.push(
         vscode.commands.registerCommand(COMMANDS.UNREGISTER_PACKAGE, async () => {
-            await services.packageManager.unregisterPackage();
+            await services.packageManager.unregisterPackage(services.projectManager.currentProject);
         })
     );
 
     context.subscriptions.push(
         vscode.commands.registerCommand(COMMANDS.MANIFEST_ADD_ALIAS, async () => {
-            await services.packageManager.addManifestAlias();
+            await services.packageManager.addManifestAlias(services.projectManager.currentProject);
         })
     );
 

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -629,7 +629,7 @@ export class PackageManager {
                     detach: runMode.label.includes('detached'),
                     debugOutput: runMode.label.includes('debug'),
                     unregisterOnExit: unregisterOnExit === 'Yes',
-                });
+                }, projectPath);
             } catch (error) {
                 vscode.window.showErrorMessage(`Failed to run packaged app: ${error}`);
             }
@@ -639,9 +639,12 @@ export class PackageManager {
     /**
      * Unregister a sideloaded dev package (v0.3.0+)
      */
-    public async unregisterPackage(): Promise<void> {
+    public async unregisterPackage(projectUri?: vscode.Uri): Promise<void> {
+        const projectPath = projectUri ? path.dirname(projectUri.fsPath) :
+            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
         const packageName = await vscode.window.showInputBox({
-            prompt: 'Enter the package name to unregister (leave empty for current project)',
+            prompt: 'Enter the package name to unregister (leave empty to let the CLI discover it)',
             placeHolder: 'Package name (optional)',
             ignoreFocusOut: true
         });
@@ -651,14 +654,17 @@ export class PackageManager {
             title: 'Unregistering dev package...',
             cancellable: false
         }, async () => {
-            await this.winAppCli.unregister(packageName || undefined);
+            await this.winAppCli.unregister(packageName || undefined, projectPath);
         });
     }
 
     /**
      * Add an app execution alias to the manifest (v0.3.0+)
      */
-    public async addManifestAlias(): Promise<void> {
+    public async addManifestAlias(projectUri?: vscode.Uri): Promise<void> {
+        const projectPath = projectUri ? path.dirname(projectUri.fsPath) :
+            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
         const alias = await vscode.window.showInputBox({
             prompt: 'Enter the app execution alias (e.g., "myapp")',
             placeHolder: 'myapp',
@@ -675,12 +681,15 @@ export class PackageManager {
         });
         if (!alias) { return; }
 
+        // Resolve manifest path from the project
+        const manifestPath = projectPath ? await this.findManifest(projectPath) : undefined;
+
         await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
             title: 'Adding app execution alias...',
             cancellable: false
         }, async () => {
-            await this.winAppCli.manifestAddAlias(alias);
+            await this.winAppCli.manifestAddAlias(alias, manifestPath, projectPath);
         });
     }
 

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -766,13 +766,19 @@ export class PackageManager {
         });
         if (!appName) { return; }
 
-        const outputUri = await vscode.window.showSaveDialog({
-            defaultUri: vscode.Uri.file('screenshot.png'),
+        const workspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        const saveDialogOptions: vscode.SaveDialogOptions = {
             filters: {
                 'PNG Image': ['png']
             },
             title: 'Save Screenshot'
-        });
+        };
+
+        if (workspaceUri) {
+            saveDialogOptions.defaultUri = vscode.Uri.joinPath(workspaceUri, 'screenshot.png');
+        }
+
+        const outputUri = await vscode.window.showSaveDialog(saveDialogOptions);
         if (!outputUri) { return; }
 
         await vscode.window.withProgress({

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -602,11 +602,15 @@ export class PackageManager {
         const inputFolder = folderUris[0].fsPath;
 
         // Ask for run options
-        const runMode = await vscode.window.showQuickPick(
+        type RunModePick = vscode.QuickPickItem & {
+            mode: 'wait' | 'detach' | 'debugOutput';
+        };
+
+        const runMode = await vscode.window.showQuickPick<RunModePick>(
             [
-                { label: 'Run (wait for exit)', description: 'Launch and wait for the app to close' },
-                { label: 'Run detached', description: 'Launch and return control immediately' },
-                { label: 'Run with debug output', description: 'Capture OutputDebugString and crash dumps' },
+                { label: 'Run (wait for exit)', description: 'Launch and wait for the app to close', mode: 'wait' },
+                { label: 'Run detached', description: 'Launch and return control immediately', mode: 'detach' },
+                { label: 'Run with debug output', description: 'Capture OutputDebugString and crash dumps', mode: 'debugOutput' },
             ],
             { placeHolder: 'Select run mode' }
         );
@@ -626,8 +630,8 @@ export class PackageManager {
             try {
                 await this.winAppCli.run({
                     inputFolder,
-                    detach: runMode.label.includes('detached'),
-                    debugOutput: runMode.label.includes('debug'),
+                    detach: runMode.mode === 'detach',
+                    debugOutput: runMode.mode === 'debugOutput',
                     unregisterOnExit: unregisterOnExit === 'Yes',
                 }, projectPath);
             } catch (error) {

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -647,6 +647,11 @@ export class PackageManager {
         const projectPath = projectUri ? path.dirname(projectUri.fsPath) :
             vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
+        if (!projectPath) {
+            vscode.window.showErrorMessage('No WinUI project selected or workspace folder open');
+            return;
+        }
+
         const packageName = await vscode.window.showInputBox({
             prompt: 'Enter the package name to unregister (leave empty to let the CLI discover it)',
             placeHolder: 'Package name (optional)',

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -569,6 +569,203 @@ export class PackageManager {
         });
     }
 
+    // ============================================
+    // Run & Manage Operations (v0.3.0+)
+    // ============================================
+
+    /**
+     * Run application as a packaged app (v0.3.0+)
+     */
+    public async runPackagedApp(projectUri?: vscode.Uri): Promise<void> {
+        const projectPath = projectUri ? path.dirname(projectUri.fsPath) :
+            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+        if (!projectPath) {
+            vscode.window.showErrorMessage('No project selected.');
+            return;
+        }
+
+        // Ask for build output folder
+        const folderUris = await vscode.window.showOpenDialog({
+            defaultUri: vscode.Uri.file(projectPath),
+            canSelectFolders: true,
+            canSelectFiles: false,
+            canSelectMany: false,
+            openLabel: 'Select build output folder',
+            title: 'Select the folder containing your built app'
+        });
+
+        if (!folderUris || folderUris.length === 0) {
+            return;
+        }
+
+        const inputFolder = folderUris[0].fsPath;
+
+        // Ask for run options
+        const runMode = await vscode.window.showQuickPick(
+            [
+                { label: 'Run (wait for exit)', description: 'Launch and wait for the app to close' },
+                { label: 'Run detached', description: 'Launch and return control immediately' },
+                { label: 'Run with debug output', description: 'Capture OutputDebugString and crash dumps' },
+            ],
+            { placeHolder: 'Select run mode' }
+        );
+        if (!runMode) { return; }
+
+        const unregisterOnExit = await vscode.window.showQuickPick(
+            ['Yes', 'No'],
+            { placeHolder: 'Unregister package when app exits?' }
+        );
+        if (!unregisterOnExit) { return; }
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Launching packaged app...',
+            cancellable: false
+        }, async () => {
+            try {
+                await this.winAppCli.run({
+                    inputFolder,
+                    detach: runMode.label.includes('detached'),
+                    debugOutput: runMode.label.includes('debug'),
+                    unregisterOnExit: unregisterOnExit === 'Yes',
+                });
+            } catch (error) {
+                vscode.window.showErrorMessage(`Failed to run packaged app: ${error}`);
+            }
+        });
+    }
+
+    /**
+     * Unregister a sideloaded dev package (v0.3.0+)
+     */
+    public async unregisterPackage(): Promise<void> {
+        const packageName = await vscode.window.showInputBox({
+            prompt: 'Enter the package name to unregister (leave empty for current project)',
+            placeHolder: 'Package name (optional)',
+            ignoreFocusOut: true
+        });
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Unregistering dev package...',
+            cancellable: false
+        }, async () => {
+            await this.winAppCli.unregister(packageName || undefined);
+        });
+    }
+
+    /**
+     * Add an app execution alias to the manifest (v0.3.0+)
+     */
+    public async addManifestAlias(): Promise<void> {
+        const alias = await vscode.window.showInputBox({
+            prompt: 'Enter the app execution alias (e.g., "myapp")',
+            placeHolder: 'myapp',
+            ignoreFocusOut: true,
+            validateInput: (value) => {
+                if (!value.trim()) {
+                    return 'Alias cannot be empty';
+                }
+                if (/[^a-zA-Z0-9._-]/.test(value)) {
+                    return 'Alias can only contain letters, numbers, dots, hyphens, and underscores';
+                }
+                return null;
+            }
+        });
+        if (!alias) { return; }
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Adding app execution alias...',
+            cancellable: false
+        }, async () => {
+            await this.winAppCli.manifestAddAlias(alias);
+        });
+    }
+
+    // ============================================
+    // UI Automation Operations (v0.3.0+)
+    // ============================================
+
+    /**
+     * List all visible windows (v0.3.0+)
+     */
+    public async uiListWindows(): Promise<void> {
+        const appName = await vscode.window.showInputBox({
+            prompt: 'Enter app name to filter (leave empty for all windows)',
+            placeHolder: 'App name (optional)',
+            ignoreFocusOut: true
+        });
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Listing windows...',
+            cancellable: false
+        }, async () => {
+            const result = await this.winAppCli.uiListWindows(appName || undefined);
+            if (result) {
+                this.outputChannel.appendLine('--- Windows ---');
+                this.outputChannel.appendLine(result);
+                this.outputChannel.show();
+            }
+        });
+    }
+
+    /**
+     * Inspect UI tree of a running app (v0.3.0+)
+     */
+    public async uiInspect(): Promise<void> {
+        const appName = await vscode.window.showInputBox({
+            prompt: 'Enter the app name to inspect',
+            placeHolder: 'App name',
+            ignoreFocusOut: true
+        });
+        if (!appName) { return; }
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Inspecting UI tree...',
+            cancellable: false
+        }, async () => {
+            const result = await this.winAppCli.uiInspect(appName);
+            if (result) {
+                this.outputChannel.appendLine(`--- UI Tree: ${appName} ---`);
+                this.outputChannel.appendLine(result);
+                this.outputChannel.show();
+            }
+        });
+    }
+
+    /**
+     * Take a screenshot of an app window (v0.3.0+)
+     */
+    public async uiScreenshot(): Promise<void> {
+        const appName = await vscode.window.showInputBox({
+            prompt: 'Enter the app name to screenshot',
+            placeHolder: 'App name',
+            ignoreFocusOut: true
+        });
+        if (!appName) { return; }
+
+        const outputUri = await vscode.window.showSaveDialog({
+            defaultUri: vscode.Uri.file('screenshot.png'),
+            filters: {
+                'PNG Image': ['png']
+            },
+            title: 'Save Screenshot'
+        });
+        if (!outputUri) { return; }
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Taking screenshot...',
+            cancellable: false
+        }, async () => {
+            await this.winAppCli.uiScreenshot(appName, outputUri.fsPath);
+        });
+    }
+
     /**
      * Dispose of resources
      */

--- a/src/winAppCli.ts
+++ b/src/winAppCli.ts
@@ -596,6 +596,151 @@ export class WinAppCli {
         }
     }
 
+    // ============================================
+    // Run & Unregister Commands (v0.3.0+)
+    // ============================================
+
+    /**
+     * Run an application as a packaged app (v0.3.0+)
+     * Registers a loose package, launches the app, and preserves LocalState across re-deploys.
+     * @param options Run options
+     */
+    public async run(options: RunOptions): Promise<void> {
+        try {
+            const args: string[] = [];
+            if (options.inputFolder) {
+                args.push(options.inputFolder);
+            }
+            if (options.manifest) {
+                args.push('--manifest', options.manifest);
+            }
+            if (options.detach) {
+                args.push('--detach');
+            }
+            if (options.unregisterOnExit) {
+                args.push('--unregister-on-exit');
+            }
+            if (options.debugOutput) {
+                args.push('--debug-output');
+            }
+            if (options.symbols) {
+                args.push('--symbols');
+            }
+            await this.execute('run', args);
+            vscode.window.showInformationMessage('Packaged app launched successfully.');
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to run packaged app: ${error}`);
+        }
+    }
+
+    /**
+     * Unregister a sideloaded dev package (v0.3.0+)
+     * Cleanup counterpart to `winapp run`.
+     * @param packageName Optional package name to unregister
+     */
+    public async unregister(packageName?: string): Promise<void> {
+        try {
+            const args: string[] = [];
+            if (packageName) {
+                args.push(packageName);
+            }
+            await this.execute('unregister', args);
+            vscode.window.showInformationMessage('Package unregistered successfully.');
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to unregister package: ${error}`);
+        }
+    }
+
+    // ============================================
+    // Manifest Add Alias Command (v0.3.0+)
+    // ============================================
+
+    /**
+     * Add an app execution alias to the manifest (v0.3.0+)
+     * Adds a uap5:AppExecutionAlias so a packaged app can be launched by name.
+     * @param alias The alias name (e.g., "myapp")
+     * @param manifestPath Optional path to the manifest file
+     */
+    public async manifestAddAlias(alias: string, manifestPath?: string): Promise<void> {
+        try {
+            const args: string[] = ['add-alias', alias];
+            if (manifestPath) {
+                args.push('--manifest', manifestPath);
+            }
+            await this.execute('manifest', args);
+            vscode.window.showInformationMessage(`App execution alias '${alias}' added to manifest.`);
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to add alias: ${error}`);
+        }
+    }
+
+    // ============================================
+    // UI Automation Commands (v0.3.0+)
+    // ============================================
+
+    /**
+     * List all visible windows (v0.3.0+)
+     * @param appName Optional app name filter
+     */
+    public async uiListWindows(appName?: string): Promise<string> {
+        try {
+            const args: string[] = ['list-windows'];
+            if (appName) {
+                args.push('-a', appName);
+            }
+            return await this.execute('ui', args);
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to list windows: ${error}`);
+            return '';
+        }
+    }
+
+    /**
+     * Inspect the UI tree of a running app (v0.3.0+)
+     * @param appName App name to inspect
+     * @param interactive Whether to use interactive mode
+     */
+    public async uiInspect(appName: string, interactive: boolean = false): Promise<string> {
+        try {
+            const args: string[] = ['inspect', '-a', appName];
+            if (interactive) {
+                args.push('-i');
+            }
+            return await this.execute('ui', args);
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to inspect UI: ${error}`);
+            return '';
+        }
+    }
+
+    /**
+     * Take a screenshot of an app window (v0.3.0+)
+     * @param appName App name to screenshot
+     * @param outputPath Output file path for the screenshot
+     */
+    public async uiScreenshot(appName: string, outputPath: string): Promise<void> {
+        try {
+            await this.execute('ui', ['screenshot', '-a', appName, '-o', outputPath]);
+            vscode.window.showInformationMessage(`Screenshot saved to ${outputPath}`);
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to take screenshot: ${error}`);
+        }
+    }
+
+    /**
+     * Search for UI elements by name (v0.3.0+)
+     * @param query Search query
+     * @param appName App name to search in
+     */
+    public async uiSearch(query: string, appName: string): Promise<string> {
+        try {
+            return await this.execute('ui', ['search', query, '-a', appName]);
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to search UI elements: ${error}`);
+            return '';
+        }
+    }
+
     /**
      * Dispose of resources
      */
@@ -654,4 +799,15 @@ export interface StorePackageOptions {
     output?: string;
     arch?: ('x86' | 'x64' | 'arm64')[];
     version?: string;
+}
+
+// Run options (v0.3.0+)
+
+export interface RunOptions {
+    inputFolder?: string;
+    manifest?: string;
+    detach?: boolean;
+    unregisterOnExit?: boolean;
+    debugOutput?: boolean;
+    symbols?: boolean;
 }

--- a/src/winAppCli.ts
+++ b/src/winAppCli.ts
@@ -608,10 +608,12 @@ export class WinAppCli {
      */
     public async run(options: RunOptions, cwd?: string): Promise<void> {
         try {
-            const args: string[] = [];
-            if (options.inputFolder) {
-                args.push(options.inputFolder);
+            const inputFolder = options.inputFolder.trim();
+            if (!inputFolder) {
+                throw new Error('An input folder is required to run a packaged app.');
             }
+
+            const args: string[] = [inputFolder];
             if (options.manifest) {
                 args.push('--manifest', options.manifest);
             }
@@ -807,7 +809,7 @@ export interface StorePackageOptions {
 // Run options (v0.3.0+)
 
 export interface RunOptions {
-    inputFolder?: string;
+    inputFolder: string;
     manifest?: string;
     detach?: boolean;
     unregisterOnExit?: boolean;

--- a/src/winAppCli.ts
+++ b/src/winAppCli.ts
@@ -604,8 +604,9 @@ export class WinAppCli {
      * Run an application as a packaged app (v0.3.0+)
      * Registers a loose package, launches the app, and preserves LocalState across re-deploys.
      * @param options Run options
+     * @param cwd Optional working directory for the command
      */
-    public async run(options: RunOptions): Promise<void> {
+    public async run(options: RunOptions, cwd?: string): Promise<void> {
         try {
             const args: string[] = [];
             if (options.inputFolder) {
@@ -626,7 +627,7 @@ export class WinAppCli {
             if (options.symbols) {
                 args.push('--symbols');
             }
-            await this.execute('run', args);
+            await this.execute('run', args, cwd);
             vscode.window.showInformationMessage('Packaged app launched successfully.');
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to run packaged app: ${error}`);
@@ -637,14 +638,15 @@ export class WinAppCli {
      * Unregister a sideloaded dev package (v0.3.0+)
      * Cleanup counterpart to `winapp run`.
      * @param packageName Optional package name to unregister
+     * @param cwd Optional working directory for the command
      */
-    public async unregister(packageName?: string): Promise<void> {
+    public async unregister(packageName?: string, cwd?: string): Promise<void> {
         try {
             const args: string[] = [];
             if (packageName) {
                 args.push(packageName);
             }
-            await this.execute('unregister', args);
+            await this.execute('unregister', args, cwd);
             vscode.window.showInformationMessage('Package unregistered successfully.');
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to unregister package: ${error}`);
@@ -660,14 +662,15 @@ export class WinAppCli {
      * Adds a uap5:AppExecutionAlias so a packaged app can be launched by name.
      * @param alias The alias name (e.g., "myapp")
      * @param manifestPath Optional path to the manifest file
+     * @param cwd Optional working directory for the command
      */
-    public async manifestAddAlias(alias: string, manifestPath?: string): Promise<void> {
+    public async manifestAddAlias(alias: string, manifestPath?: string, cwd?: string): Promise<void> {
         try {
             const args: string[] = ['add-alias', alias];
             if (manifestPath) {
                 args.push('--manifest', manifestPath);
             }
-            await this.execute('manifest', args);
+            await this.execute('manifest', args, cwd);
             vscode.window.showInformationMessage(`App execution alias '${alias}' added to manifest.`);
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to add alias: ${error}`);


### PR DESCRIPTION
### New Commands (6)

| Command | Description |
| --- | --- |
| **WinDev: Run as Packaged App** | Launch app from build output as packaged (detach, debug output, unregister-on-exit modes) |
| **WinDev: Unregister Dev Package** | Clean up sideloaded packages registered by [winapp run](vscode-file://vscode-app/c:/Users/alash/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) |
| **WinDev: Add App Execution Alias** | Add `uap5:AppExecutionAlias` to manifest for CLI-launchable apps |
| **WinDev: UI: List Windows** | Enumerate visible app windows |
| **WinDev: UI: Inspect App** | Walk UI Automation tree of a running app |
| **WinDev: UI: Take Screenshot** | Capture app window screenshots |