### PR TITLE
Updates for winapp extension parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to the WinDev Helper extension will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2026-05-05
+
+> ⚠️ The preview pane and properties panel features are currently in preview. Please report any bugs or suggestions to our GitHub issues.
+
+This release brings WinDev Helper closer to feature parity with the official [Microsoft WinApp VS Code extension](https://marketplace.visualstudio.com/items?itemName=Microsoft-WinAppCLI.winapp) and adds support for the new official Microsoft Windows App SDK templates.
+
+### Added
+
+- **`winapp` debug type** (parity with the official Microsoft WinApp VS Code extension)
+  - New custom debug type that launches the build output via `winapp run` (so the app gets package identity) and then attaches the requested debugger
+  - Supports `coreclr` (default, C# / .NET via C# Dev Kit), `cppvsdbg` (C / C++), and `node` (Node.js / Electron) child debuggers
+  - Configuration properties: `inputFolder`, `manifest`, `debuggerType`, `workingDirectory`, `args`, `outputAppxDirectory`
+  - Auto-detects the build output folder by scanning for `.exe` files (skips `createdump.exe`, `apphost.exe`, and `singlefilehost.exe`)
+  - Includes an initial configuration so picking *WinApp* from the F5 picker works without an existing `launch.json`
+
+- **WinDev: Configure WinApp Debug & Tasks**
+  - Scaffolds `.vscode/launch.json` and `.vscode/tasks.json` with the recommended `winapp` configuration plus a matching `preLaunchTask` (build) — based on the sample shown in [Chiara Mooney's announcement post](https://devblogs.microsoft.com/ifdef-windows/announcing-the-winapp-vs-code-extension-run-debug-and-package-windows-apps-in-vs-code/)
+  - Prompts for project type (.NET, C/C++, Node.js/Electron, or Other) and emits the appropriate build task
+  - Merges into existing files without overwriting unrelated entries
+
+- **WinDev: Update Manifest Assets** (winapp CLI v0.2.1+)
+  - Wraps `winapp manifest update-assets` to auto-generate all required app icon sizes from a single source image (PNG, JPG, GIF, BMP, or SVG)
+
+- **WinDev: Run SDK Tool**
+  - Provides direct access to `makeappx`, `signtool`, `mt`, and `makepri` via `winapp tool`, with custom argument tokenization
+
+- **WinDev: Get WinApp Path**
+  - Surfaces the paths reported by `winapp get-winapp-path` in the WinUI Packaging output channel
+
+- **Support for the official Microsoft WinUI templates** ([Microsoft.WindowsAppSDK.WinUI.CSharp.Templates](https://www.nuget.org/packages/Microsoft.WindowsAppSDK.WinUI.CSharp.Templates))
+  - The package is currently in alpha. **WinDev: Install WinUI Templates** now lets you choose between the official Microsoft pack and the existing community pack
+  - **WinDev: Create WinUI Project** offers the official `winui`, `winui-mvvm`, `winui-navview`, and `winui-unittest` variants when the official pack is selected
+  - **WinDev: Create WinUI Library** uses `winui-lib` (official) or `winuilib` (community) automatically
+  - New `windevHelper.templates.source` setting (`auto`, `official`, `community`) controls the preference; `auto` prefers the official pack when installed and falls back to the community pack
+  - New `windevHelper.templates.allowPrerelease` setting installs the alpha (`*-*`) version of the official pack until a stable release ships
+
+### Changed
+
+- **`winapp run`** now accepts an `outputAppxDirectory` option (mirrors `--output`) so the loose-layout package can be redirected when needed by the new debug type
+
 ## [2.9.0] - 2026-05-04
 
 > ⚠️ The preview pane and properties panel features are currently in preview. Please report any bugs or suggestions to our GitHub issues.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ On non-Windows platforms, the extension provides an HTML-based preview renderer 
 - Create WinUI class libraries
 - Add new Pages, Windows, and User Controls to your project
 - **Automatic MVVM setup** - Global usings for CommunityToolkit.Mvvm are automatically added when creating views
-- Powered by [WinUI Templates](https://github.com/egvijayanand/winui-templates)
+- Supports both the [official Microsoft Windows App SDK templates](https://www.nuget.org/packages/Microsoft.WindowsAppSDK.WinUI.CSharp.Templates) (currently in alpha) and the [community WinUI Templates](https://github.com/egvijayanand/winui-templates); pick a preference via `windevHelper.templates.source`
 
 ### 🛠️ App Manifest Management
 
@@ -116,7 +116,9 @@ This extension requires the following VS Code extensions:
 - **.NET 8 SDK** or later - [Download](https://dotnet.microsoft.com/download)
 - **Windows App SDK** - Automatically referenced in WinUI projects
 - **Windows App Development CLI (winapp)** - [Learn more](https://github.com/microsoft/WinAppCli)
-- **WinUI Templates** - Install with: `dotnet new install VijayAnand.WinUITemplates`
+- **WinUI Templates** - Install with `WinUI: Install WinUI Templates`, or directly:
+  - Official (alpha): `dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates::*-*`
+  - Community: `dotnet new install VijayAnand.WinUITemplates`
 
 ### System Requirements
 
@@ -132,7 +134,9 @@ This extension requires the following VS Code extensions:
 # Install .NET 8 SDK (if not already installed)
 winget install Microsoft.DotNet.SDK.8
 
-# Install WinUI Templates
+# Install WinUI Templates (pick one)
+dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates::*-*
+# or the community pack
 dotnet new install VijayAnand.WinUITemplates
 
 # Install Windows App Development CLI
@@ -204,6 +208,10 @@ dotnet new winuilib -n MyLib
 | `WinDev: UI: List Windows` | List visible app windows |
 | `WinDev: UI: Inspect App` | Inspect UI Automation tree |
 | `WinDev: UI: Take Screenshot` | Capture app window screenshot |
+| `WinDev: Update Manifest Assets` | Auto-generate app icon assets from a single source image |
+| `WinDev: Run SDK Tool` | Run `makeappx`, `signtool`, `mt`, or `makepri` via `winapp tool` |
+| `WinDev: Get WinApp Path` | Show paths to installed Windows SDK components |
+| `WinDev: Configure WinApp Debug & Tasks` | Scaffold `.vscode/launch.json` and `.vscode/tasks.json` for the `winapp` debug type |
 
 ## Extension Settings
 
@@ -222,6 +230,8 @@ This extension contributes the following settings:
 | `windevHelper.preview.width` | number | `800` | Default preview width |
 | `windevHelper.preview.height` | number | `600` | Default preview height |
 | `windevHelper.preview.updateDelay` | number | `300` | Delay (ms) before updating preview after edits |
+| `windevHelper.templates.source` | string | `auto` | Template package preference: `auto`, `official`, or `community` |
+| `windevHelper.templates.allowPrerelease` | boolean | `true` | Install prerelease versions of the official Microsoft template pack while it remains in alpha |
 
 ## Keyboard Shortcuts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windev-helper",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windev-helper",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "windev-helper",
   "displayName": "WinDev Helper",
   "description": "Build beautiful, performant WinUI apps with VS Code. Debug, build, package, and deploy Windows apps powered by the Windows App SDK.",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "publisher": "alvinashcraft",
   "preview": true,
   "icon": "images/icon.png",
@@ -235,6 +235,26 @@
         "category": "WinDev"
       },
       {
+        "command": "windev-helper.manifestUpdateAssets",
+        "title": "Update Manifest Assets",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.runSdkTool",
+        "title": "Run SDK Tool",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.getWinAppPath",
+        "title": "Get WinApp Path",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.configureWinAppDebug",
+        "title": "Configure WinApp Debug & Tasks",
+        "category": "WinDev"
+      },
+      {
         "command": "windev-helper.openXamlPreview",
         "title": "Open XAML Preview",
         "category": "WinDev",
@@ -463,6 +483,26 @@
           ],
           "default": "auto",
           "description": "Theme for XAML preview. 'auto' follows VS Code theme or project's App.xaml RequestedTheme."
+        },
+        "windevHelper.templates.source": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "official",
+            "community"
+          ],
+          "enumDescriptions": [
+            "Prefer the official Microsoft templates if installed; otherwise fall back to the community templates.",
+            "Use the official Microsoft.WindowsAppSDK.WinUI.CSharp.Templates package (currently in alpha).",
+            "Use the community VijayAnand.WinUITemplates package."
+          ],
+          "default": "auto",
+          "description": "Which dotnet template package to use when scaffolding WinUI projects and items."
+        },
+        "windevHelper.templates.allowPrerelease": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow installing prerelease versions of the official Microsoft WinUI template package (the alpha is required while the package is still in preview)."
         }
       }
     },
@@ -572,6 +612,76 @@
               "project": "${workspaceFolder}/${1:MyApp}.csproj",
               "configuration": "${2:Debug}",
               "platform": "${3:x64}"
+            }
+          }
+        ]
+      },
+      {
+        "type": "winapp",
+        "label": "WinApp",
+        "languages": [
+          "csharp",
+          "cpp",
+          "c",
+          "javascript",
+          "typescript"
+        ],
+        "configurationAttributes": {
+          "launch": {
+            "properties": {
+              "inputFolder": {
+                "type": "string",
+                "description": "Path to the build output folder containing your app binaries (e.g., ${workspaceFolder}/bin/Debug/net8.0-windows10.0.22621). If not set, you will be prompted to select a folder."
+              },
+              "manifest": {
+                "type": "string",
+                "description": "Path to the AppxManifest.xml file. If not set, the CLI auto-detects from the input folder or current directory."
+              },
+              "debuggerType": {
+                "type": "string",
+                "enum": [
+                  "coreclr",
+                  "cppvsdbg",
+                  "node"
+                ],
+                "default": "coreclr",
+                "description": "Underlying debugger to use after the app is launched with package identity."
+              },
+              "workingDirectory": {
+                "type": "string",
+                "description": "Working directory for the application. Defaults to the build output folder."
+              },
+              "args": {
+                "type": [
+                  "string",
+                  "array"
+                ],
+                "description": "Command-line arguments to pass to the application (forwarded after `--`)."
+              },
+              "outputAppxDirectory": {
+                "type": "string",
+                "description": "Output directory for the loose-layout package. Defaults to an AppX folder inside the input folder."
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "type": "winapp",
+            "request": "launch",
+            "name": "WinApp: Launch and Attach"
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "WinApp: Launch and Attach",
+            "description": "Launch a Windows app with package identity via 'winapp run' and attach the debugger.",
+            "body": {
+              "type": "winapp",
+              "request": "launch",
+              "name": "WinApp: Launch and Attach",
+              "preLaunchTask": "${1:winapp: build}",
+              "debuggerType": "${2|coreclr,cppvsdbg,node|}"
             }
           }
         ]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,8 @@ export const CONFIG = {
     AUTO_RESTORE_ON_OPEN: 'autoRestoreOnOpen',
     SHOW_STATUS_BAR_ITEMS: 'showStatusBarItems',
     CERTIFICATE_PATH: 'certificatePath',
+    TEMPLATES_SOURCE: 'templates.source',
+    TEMPLATES_ALLOW_PRERELEASE: 'templates.allowPrerelease',
 } as const;
 
 /**
@@ -69,6 +71,11 @@ export const COMMANDS = {
     UI_LIST_WINDOWS: 'windev-helper.uiListWindows',
     UI_INSPECT: 'windev-helper.uiInspect',
     UI_SCREENSHOT: 'windev-helper.uiScreenshot',
+    // Parity commands with the official Microsoft WinApp VS Code extension (v2.10.0+)
+    MANIFEST_UPDATE_ASSETS: 'windev-helper.manifestUpdateAssets',
+    RUN_SDK_TOOL: 'windev-helper.runSdkTool',
+    GET_WINAPP_PATH: 'windev-helper.getWinAppPath',
+    CONFIGURE_WINAPP_DEBUG: 'windev-helper.configureWinAppDebug',
 } as const;
 
 /**
@@ -79,6 +86,7 @@ export const OUTPUT_CHANNELS = {
     PACKAGING: 'WinUI Packaging',
     TEMPLATES: 'WinUI Templates',
     WINAPP_CLI: 'WinApp CLI',
+    WINAPP_DEBUG: 'WinApp Debug',
 } as const;
 
 /**
@@ -87,6 +95,14 @@ export const OUTPUT_CHANNELS = {
 export const DEBUG_TYPES = {
     WINUI: 'winui',
     CORECLR: 'coreclr',
+    /**
+     * Custom WinApp debug type (parity with the official Microsoft WinApp
+     * VS Code extension). Launches the build output via `winapp run` so the
+     * app gets package identity, then attaches a child debugger.
+     */
+    WINAPP: 'winapp',
+    CPPVSDBG: 'cppvsdbg',
+    NODE: 'node',
 } as const;
 
 /**
@@ -117,3 +133,40 @@ export const DEFAULTS = {
     TARGET_FRAMEWORK: 'net8.0-windows10.0.19041.0',
     TIMESTAMP_URL: 'http://timestamp.digicert.com',
 } as const;
+
+/**
+ * Identifiers for the supported `dotnet new` template packages.
+ *
+ * - `OFFICIAL`: Microsoft.WindowsAppSDK.WinUI.CSharp.Templates (alpha) ships the
+ *   blank-app, MVVM, NavigationView, library, and unit-test templates plus the
+ *   common item templates (page, window, user control, templated control,
+ *   resource dictionary, RESW, dialog).
+ * - `COMMUNITY`: VijayAnand.WinUITemplates is the long-standing community pack
+ *   that this extension has used since launch and remains the default for users
+ *   who already rely on its short names (`winuilib`, `-mvvm` flag).
+ */
+export const TEMPLATE_PACKAGES = {
+    OFFICIAL: 'Microsoft.WindowsAppSDK.WinUI.CSharp.Templates',
+    COMMUNITY: 'VijayAnand.WinUITemplates',
+} as const;
+
+/**
+ * Project template short names exposed by the supported template packages.
+ * The `OFFICIAL` package adds dedicated MVVM, NavigationView, library, and
+ * unit-test templates; the `COMMUNITY` package uses a single `winui` template
+ * with a `-mvvm` flag and a `winuilib` library template.
+ */
+export const TEMPLATE_NAMES = {
+    OFFICIAL: {
+        BLANK: 'winui',
+        MVVM: 'winui-mvvm',
+        NAVIGATION_VIEW: 'winui-navview',
+        LIBRARY: 'winui-lib',
+        UNIT_TEST: 'winui-unittest',
+    },
+    COMMUNITY: {
+        BLANK: 'winui',
+        LIBRARY: 'winuilib',
+    },
+} as const;
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,14 +60,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Register the `winapp` debug type — parity with the official Microsoft
     // WinApp VS Code extension. Launches the build output via `winapp run`
     // (package identity) and attaches the requested debugger.
+    //
+    // We register the provider only once. Initial F5 configurations are
+    // contributed statically via the `initialConfigurations` entry in
+    // package.json, so a `Dynamic` registration is unnecessary and would
+    // cause `resolveDebugConfiguration*` to fire twice (launching / attaching
+    // the app twice).
     winAppDebugProvider = new WinAppDebugConfigurationProvider(services.winAppCli);
     context.subscriptions.push(
-        vscode.debug.registerDebugConfigurationProvider(DEBUG_TYPES.WINAPP, winAppDebugProvider),
-        vscode.debug.registerDebugConfigurationProvider(
-            DEBUG_TYPES.WINAPP,
-            winAppDebugProvider,
-            vscode.DebugConfigurationProviderTriggerKind.Dynamic
-        )
+        vscode.debug.registerDebugConfigurationProvider(DEBUG_TYPES.WINAPP, winAppDebugProvider)
     );
 
     // Register all commands

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@
 
 import * as vscode from 'vscode';
 import { DebugConfigurationProvider } from './debugConfigurationProvider';
+import { WinAppDebugConfigurationProvider } from './winAppDebugProvider';
 import { ServiceLocator } from './serviceLocator';
 import { COMMANDS, CONFIG, DEBUG_TYPES } from './constants';
 import { XamlPreviewController } from './xamlPreview';
@@ -14,6 +15,7 @@ let services: ServiceLocator;
 let previewController: XamlPreviewController;
 let propertyPaneController: PropertyPaneController;
 let designerSelectionSubscription: vscode.Disposable | undefined;
+let winAppDebugProvider: WinAppDebugConfigurationProvider | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     console.log('WinDev Helper extension is now active');
@@ -53,6 +55,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     );
     context.subscriptions.push(
         vscode.debug.registerDebugConfigurationProvider(DEBUG_TYPES.WINUI, debugProvider)
+    );
+
+    // Register the `winapp` debug type — parity with the official Microsoft
+    // WinApp VS Code extension. Launches the build output via `winapp run`
+    // (package identity) and attaches the requested debugger.
+    winAppDebugProvider = new WinAppDebugConfigurationProvider(services.winAppCli);
+    context.subscriptions.push(
+        vscode.debug.registerDebugConfigurationProvider(DEBUG_TYPES.WINAPP, winAppDebugProvider),
+        vscode.debug.registerDebugConfigurationProvider(
+            DEBUG_TYPES.WINAPP,
+            winAppDebugProvider,
+            vscode.DebugConfigurationProviderTriggerKind.Dynamic
+        )
     );
 
     // Register all commands
@@ -342,6 +357,31 @@ function registerCommands(context: vscode.ExtensionContext): void {
         })
     );
 
+    // Parity commands with the official Microsoft WinApp VS Code extension
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.MANIFEST_UPDATE_ASSETS, async () => {
+            await services.packageManager.manifestUpdateAssets(services.projectManager.currentProject);
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.RUN_SDK_TOOL, async () => {
+            await services.packageManager.runSdkTool();
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.GET_WINAPP_PATH, async () => {
+            await services.packageManager.getWinAppPath();
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.CONFIGURE_WINAPP_DEBUG, async () => {
+            await services.packageManager.configureWinAppDebug(services.projectManager.currentProject);
+        })
+    );
+
     // XAML Preview command
     context.subscriptions.push(
         vscode.commands.registerCommand(COMMANDS.OPEN_XAML_PREVIEW, async () => {
@@ -361,4 +401,5 @@ export function deactivate(): void {
     if (ServiceLocator.isInitialized) {
         services.dispose();
     }
+    winAppDebugProvider?.dispose();
 }

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -882,6 +882,275 @@ export class PackageManager {
         });
     }
 
+    // ============================================
+    // Parity commands with the official Microsoft WinApp VS Code extension
+    // ============================================
+
+    /**
+     * Auto-generate all required app icon assets from a single source image
+     * (PNG, JPG, GIF, BMP, or SVG). Wraps `winapp manifest update-assets`.
+     */
+    public async manifestUpdateAssets(projectUri?: vscode.Uri): Promise<void> {
+        const projectPath = projectUri ? path.dirname(projectUri.fsPath) :
+            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+        const imageUris = await vscode.window.showOpenDialog({
+            canSelectFiles: true,
+            canSelectFolders: false,
+            canSelectMany: false,
+            filters: {
+                'Source images': ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'svg']
+            },
+            title: 'Select source image to generate manifest assets from'
+        });
+        if (!imageUris || imageUris.length === 0) { return; }
+
+        const manifestPath = projectPath ? await this.findManifest(projectPath) : undefined;
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Generating manifest assets...',
+            cancellable: false
+        }, async () => {
+            await this.winAppCli.manifestUpdateAssets(imageUris[0].fsPath, manifestPath, projectPath);
+        });
+    }
+
+    /**
+     * Run a Windows SDK tool (makeappx, signtool, mt, makepri) with custom
+     * arguments. Wraps `winapp tool <name> -- <args>`.
+     */
+    public async runSdkTool(): Promise<void> {
+        const toolName = await vscode.window.showQuickPick(
+            [
+                { label: 'makeappx', description: 'Create or extract MSIX packages' },
+                { label: 'signtool', description: 'Sign packages and executables' },
+                { label: 'mt', description: 'Manifest tool' },
+                { label: 'makepri', description: 'Build the package resource index' },
+            ],
+            { placeHolder: 'Select an SDK tool to run' }
+        );
+        if (!toolName) { return; }
+
+        const argsInput = await vscode.window.showInputBox({
+            prompt: `Arguments to pass to ${toolName.label} (leave empty for help)`,
+            placeHolder: '/?',
+            ignoreFocusOut: true
+        });
+        if (argsInput === undefined) { return; }
+
+        const args = this.parseAppArgs(argsInput);
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: `Running ${toolName.label}...`,
+            cancellable: false
+        }, async () => {
+            try {
+                const output = await this.winAppCli.tool(toolName.label, args);
+                if (output) {
+                    this.outputChannel.appendLine(`--- ${toolName.label} output ---`);
+                    this.outputChannel.appendLine(output);
+                    this.outputChannel.show();
+                }
+            } catch (error) {
+                vscode.window.showErrorMessage(`${toolName.label} failed: ${error}`);
+            }
+        });
+    }
+
+    /**
+     * Display paths to installed SDK components (winapp get-winapp-path).
+     */
+    public async getWinAppPath(): Promise<void> {
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Resolving WinApp SDK paths...',
+            cancellable: false
+        }, async () => {
+            try {
+                const output = await this.winAppCli.getSdkPaths();
+                if (output) {
+                    this.outputChannel.appendLine('--- WinApp SDK paths ---');
+                    this.outputChannel.appendLine(output);
+                    this.outputChannel.show();
+                }
+            } catch (error) {
+                vscode.window.showErrorMessage(`Failed to resolve SDK paths: ${error}`);
+            }
+        });
+    }
+
+    /**
+     * Scaffold .vscode/launch.json and .vscode/tasks.json with the recommended
+     * `winapp` debug configuration and a build pre-launch task. Mirrors the
+     * sample shown in the Microsoft WinApp VS Code extension blog post.
+     */
+    public async configureWinAppDebug(projectUri?: vscode.Uri): Promise<void> {
+        const workspaceFolder = projectUri
+            ? vscode.workspace.getWorkspaceFolder(projectUri)
+            : vscode.workspace.workspaceFolders?.[0];
+
+        if (!workspaceFolder) {
+            vscode.window.showErrorMessage('No workspace folder is open. Open a folder first.');
+            return;
+        }
+
+        const projectKindPick = await vscode.window.showQuickPick(
+            [
+                { label: '.NET (C# / WinUI 3 / WPF / WinForms)', value: 'dotnet' as const, description: 'Uses `dotnet build` and the C# debugger (coreclr)' },
+                { label: 'C / C++ (CMake or MSBuild)', value: 'cpp' as const, description: 'Uses MSBuild and the cppvsdbg debugger' },
+                { label: 'Node.js / Electron', value: 'node' as const, description: 'Uses npm/yarn build and the node debugger' },
+                { label: 'Other (no preLaunchTask)', value: 'other' as const, description: 'Just adds the winapp debug config' },
+            ],
+            { placeHolder: 'Select your project type' }
+        );
+        if (!projectKindPick) { return; }
+
+        const vscodeDir = path.join(workspaceFolder.uri.fsPath, '.vscode');
+        try {
+            await fs.promises.mkdir(vscodeDir, { recursive: true });
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to create .vscode folder: ${error}`);
+            return;
+        }
+
+        const buildTaskLabel = 'winapp: build';
+
+        const buildTask = this.buildTaskForKind(projectKindPick.value, buildTaskLabel);
+
+        const launchConfig: Record<string, unknown> = {
+            type: 'winapp',
+            request: 'launch',
+            name: 'WinApp: Launch and Attach',
+        };
+
+        if (buildTask) {
+            launchConfig.preLaunchTask = buildTaskLabel;
+        }
+
+        switch (projectKindPick.value) {
+            case 'cpp':
+                launchConfig.debuggerType = 'cppvsdbg';
+                break;
+            case 'node':
+                launchConfig.debuggerType = 'node';
+                break;
+            // dotnet/other use the default coreclr debugger
+        }
+
+        try {
+            const launchPath = path.join(vscodeDir, 'launch.json');
+            await this.mergeJsonArrayFile(launchPath, {
+                version: '0.2.0',
+                configurations: [],
+            }, 'configurations', launchConfig, (existing) => existing.name === launchConfig.name);
+
+            if (buildTask) {
+                const tasksPath = path.join(vscodeDir, 'tasks.json');
+                await this.mergeJsonArrayFile(tasksPath, {
+                    version: '2.0.0',
+                    tasks: [],
+                }, 'tasks', buildTask, (existing) => existing.label === buildTaskLabel);
+            }
+
+            const action = await vscode.window.showInformationMessage(
+                buildTask
+                    ? 'WinApp debug configuration and build task added to .vscode/launch.json and .vscode/tasks.json.'
+                    : 'WinApp debug configuration added to .vscode/launch.json.',
+                'Open launch.json'
+            );
+
+            if (action === 'Open launch.json') {
+                const doc = await vscode.workspace.openTextDocument(path.join(vscodeDir, 'launch.json'));
+                await vscode.window.showTextDocument(doc);
+            }
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to write debug configuration: ${error}`);
+        }
+    }
+
+    /**
+     * Returns the recommended pre-launch build task for the given project
+     * kind, or `undefined` when no automated build is appropriate.
+     */
+    private buildTaskForKind(kind: 'dotnet' | 'cpp' | 'node' | 'other', label: string): Record<string, unknown> | undefined {
+        switch (kind) {
+            case 'dotnet':
+                return {
+                    label,
+                    command: 'dotnet',
+                    type: 'process',
+                    args: ['build', '${workspaceFolder}'],
+                    problemMatcher: '$msCompile',
+                    group: { kind: 'build', isDefault: true },
+                };
+            case 'cpp':
+                return {
+                    label,
+                    command: 'msbuild',
+                    type: 'process',
+                    args: ['${workspaceFolder}', '/t:Build', '/p:Configuration=Debug'],
+                    problemMatcher: '$msCompile',
+                    group: { kind: 'build', isDefault: true },
+                };
+            case 'node':
+                return {
+                    label,
+                    command: 'npm',
+                    type: 'shell',
+                    args: ['run', 'build'],
+                    problemMatcher: [],
+                    group: { kind: 'build', isDefault: true },
+                };
+            case 'other':
+            default:
+                return undefined;
+        }
+    }
+
+    /**
+     * Read or create a JSON file shaped as `{ <arrayKey>: [...] }`, then
+     * append `entry` to the array unless an existing element already matches
+     * `matches(existing)`. Preserves any unrelated keys in the file.
+     */
+    private async mergeJsonArrayFile(
+        filePath: string,
+        defaultShape: Record<string, unknown>,
+        arrayKey: string,
+        entry: Record<string, unknown>,
+        matches: (existing: Record<string, unknown>) => boolean
+    ): Promise<void> {
+        let parsed: Record<string, unknown> = { ...defaultShape };
+
+        try {
+            const raw = await fs.promises.readFile(filePath, 'utf-8');
+            const stripped = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:"])\/\/.*$/gm, '$1');
+            const existing = JSON.parse(stripped);
+            if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+                parsed = existing as Record<string, unknown>;
+            }
+        } catch {
+            // File missing or unparseable — fall back to the default shape.
+        }
+
+        const list = Array.isArray(parsed[arrayKey])
+            ? (parsed[arrayKey] as Record<string, unknown>[])
+            : [];
+
+        const alreadyPresent = list.some(matches);
+        if (!alreadyPresent) {
+            list.push(entry);
+        }
+        parsed[arrayKey] = list;
+
+        if (parsed.version === undefined && defaultShape.version !== undefined) {
+            parsed.version = defaultShape.version;
+        }
+
+        await fs.promises.writeFile(filePath, JSON.stringify(parsed, null, 4) + '\n', 'utf-8');
+    }
+
     /**
      * Dispose of resources
      */

--- a/src/templateManager.ts
+++ b/src/templateManager.ts
@@ -46,8 +46,11 @@ export class TemplateManager {
     }
 
     /**
-     * Returns true when `dotnet new list` reports any template owned by the
-     * given package id.
+     * Returns true when the given template package id is reported as
+     * installed by `dotnet new uninstall` (running it with no arguments
+     * lists the currently installed template packages, which is the
+     * fastest reliable way to detect installation — `dotnet new list`
+     * is much slower and only surfaces individual templates).
      */
     private async isPackageInstalled(packageId: string): Promise<boolean> {
         try {

--- a/src/templateManager.ts
+++ b/src/templateManager.ts
@@ -6,7 +6,12 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as cp from 'child_process';
 import * as fs from 'fs';
-import { OUTPUT_CHANNELS } from './constants';
+import { CONFIG, OUTPUT_CHANNELS, TEMPLATE_NAMES, TEMPLATE_PACKAGES } from './constants';
+
+/**
+ * Identifies which dotnet template package should provide a given template.
+ */
+type TemplateSource = 'official' | 'community';
 
 /**
  * Manages WinUI project and item templates
@@ -19,27 +24,109 @@ export class TemplateManager {
     }
 
     /**
-     * Installs WinUI templates from the dotnet template package
+     * Resolves which template package the user wants to use.
+     *
+     * Honors the `windevHelper.templates.source` setting. When set to `auto`,
+     * prefers the official Microsoft package if it is installed, otherwise
+     * falls back to the community package (which has been the historical
+     * default for this extension).
+     */
+    private async resolveTemplateSource(): Promise<TemplateSource> {
+        const config = vscode.workspace.getConfiguration(CONFIG.SECTION);
+        const setting = config.get<string>(CONFIG.TEMPLATES_SOURCE, 'auto');
+
+        if (setting === 'official') { return 'official'; }
+        if (setting === 'community') { return 'community'; }
+
+        // auto: prefer official when available, otherwise community
+        if (await this.isPackageInstalled(TEMPLATE_PACKAGES.OFFICIAL)) {
+            return 'official';
+        }
+        return 'community';
+    }
+
+    /**
+     * Returns true when `dotnet new list` reports any template owned by the
+     * given package id.
+     */
+    private async isPackageInstalled(packageId: string): Promise<boolean> {
+        try {
+            const output = await this.executeCommand('dotnet new uninstall', undefined, true);
+            return output.toLowerCase().includes(packageId.toLowerCase());
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Installs WinUI templates from the dotnet template package. Prompts the
+     * user when the configured source is `auto` and neither package is
+     * installed yet so they can pick between the official Microsoft package
+     * (currently in alpha) and the community package.
      */
     public async installTemplates(): Promise<void> {
+        const source = await this.pickInstallSource();
+        if (!source) { return; }
+
+        const packageId = source === 'official'
+            ? TEMPLATE_PACKAGES.OFFICIAL
+            : TEMPLATE_PACKAGES.COMMUNITY;
+
+        const config = vscode.workspace.getConfiguration(CONFIG.SECTION);
+        const allowPrerelease = config.get<boolean>(CONFIG.TEMPLATES_ALLOW_PRERELEASE, true);
+        const installCommand = source === 'official' && allowPrerelease
+            ? `dotnet new install ${packageId}::*-* --force`
+            : `dotnet new install ${packageId}`;
+
         await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
-            title: 'Installing WinUI templates...',
+            title: `Installing ${packageId}...`,
             cancellable: false
         }, async () => {
             try {
-                await this.executeCommand('dotnet new install VijayAnand.WinUITemplates');
-                vscode.window.showInformationMessage('WinUI templates installed successfully.');
+                await this.executeCommand(installCommand);
+                vscode.window.showInformationMessage(`${packageId} installed successfully.`);
             } catch (error) {
+                const learnMoreUrl = source === 'official'
+                    ? 'https://www.nuget.org/packages/Microsoft.WindowsAppSDK.WinUI.CSharp.Templates'
+                    : 'https://github.com/egvijayanand/winui-templates';
                 const action = await vscode.window.showErrorMessage(
                     `Failed to install templates: ${error}`,
                     'Learn More'
                 );
                 if (action === 'Learn More') {
-                    vscode.env.openExternal(vscode.Uri.parse('https://github.com/egvijayanand/winui-templates'));
+                    vscode.env.openExternal(vscode.Uri.parse(learnMoreUrl));
                 }
             }
         });
+    }
+
+    /**
+     * Resolves which template package to install. Honors the configured
+     * source unless it is `auto`, in which case the user is prompted.
+     */
+    private async pickInstallSource(): Promise<TemplateSource | undefined> {
+        const config = vscode.workspace.getConfiguration(CONFIG.SECTION);
+        const setting = config.get<string>(CONFIG.TEMPLATES_SOURCE, 'auto');
+        if (setting === 'official') { return 'official'; }
+        if (setting === 'community') { return 'community'; }
+
+        const pick = await vscode.window.showQuickPick(
+            [
+                {
+                    label: 'Official (Microsoft.WindowsAppSDK.WinUI.CSharp.Templates)',
+                    description: 'alpha — includes winui, winui-mvvm, winui-navview, winui-lib, winui-unittest',
+                    value: 'official' as const,
+                },
+                {
+                    label: 'Community (VijayAnand.WinUITemplates)',
+                    description: 'Stable — long-standing community pack used by previous releases',
+                    value: 'community' as const,
+                },
+            ],
+            { placeHolder: 'Which WinUI template package would you like to install?' }
+        );
+        return pick?.value;
     }
 
     /**
@@ -61,6 +148,8 @@ export class TemplateManager {
             }
         }
 
+        const source = await this.resolveTemplateSource();
+
         // Get project name
         const projectName = await vscode.window.showInputBox({
             prompt: 'Enter project name',
@@ -80,11 +169,13 @@ export class TemplateManager {
             return;
         }
 
-        // Ask for template options
-        const useMvvm = await vscode.window.showQuickPick(['Yes', 'No'], {
-            placeHolder: 'Use MVVM Toolkit?',
-            title: 'MVVM Support'
-        });
+        // Pick the template variant. The official Microsoft package exposes
+        // dedicated MVVM and NavigationView templates; the community package
+        // uses a single `winui` template with an `-mvvm` switch.
+        const variant = await this.pickProjectTemplate(source);
+        if (!variant) {
+            return;
+        }
 
         // Get target folder
         const folderUri = await vscode.window.showOpenDialog({
@@ -106,9 +197,9 @@ export class TemplateManager {
             cancellable: false
         }, async () => {
             try {
-                let command = `dotnet new winui -n ${projectName}`;
-                if (useMvvm === 'Yes') {
-                    command += ' -mvvm';
+                let command = `dotnet new ${variant.template} -n ${projectName}`;
+                if (variant.extraArgs) {
+                    command += ` ${variant.extraArgs}`;
                 }
 
                 await this.executeCommand(command, targetDir);
@@ -132,6 +223,57 @@ export class TemplateManager {
                 vscode.window.showErrorMessage(`Failed to create project: ${error}`);
             }
         });
+    }
+
+    /**
+     * Builds the quick-pick of available project template variants for the
+     * resolved source. The official Microsoft package exposes dedicated
+     * templates per scenario; the community package layers options onto a
+     * single `winui` template via switches.
+     */
+    private async pickProjectTemplate(
+        source: TemplateSource
+    ): Promise<{ template: string; extraArgs?: string } | undefined> {
+        if (source === 'official') {
+            const pick = await vscode.window.showQuickPick(
+                [
+                    {
+                        label: 'Blank App',
+                        description: 'winui — single-project MSIX-packaged blank app',
+                        value: { template: TEMPLATE_NAMES.OFFICIAL.BLANK },
+                    },
+                    {
+                        label: 'MVVM App',
+                        description: 'winui-mvvm — blank app pre-wired with CommunityToolkit.Mvvm',
+                        value: { template: TEMPLATE_NAMES.OFFICIAL.MVVM },
+                    },
+                    {
+                        label: 'NavigationView App',
+                        description: 'winui-navview — starter shell with NavigationView',
+                        value: { template: TEMPLATE_NAMES.OFFICIAL.NAVIGATION_VIEW },
+                    },
+                    {
+                        label: 'Unit Test Project',
+                        description: 'winui-unittest — packaged MSTest project for WinUI APIs',
+                        value: { template: TEMPLATE_NAMES.OFFICIAL.UNIT_TEST },
+                    },
+                ],
+                { placeHolder: 'Select a project template' }
+            );
+            return pick?.value;
+        }
+
+        // Community pack: ask up-front whether to enable the MVVM toolkit.
+        const useMvvm = await vscode.window.showQuickPick(
+            ['Yes', 'No'],
+            { placeHolder: 'Use MVVM Toolkit?', title: 'MVVM Support' }
+        );
+        if (!useMvvm) { return undefined; }
+
+        return {
+            template: TEMPLATE_NAMES.COMMUNITY.BLANK,
+            ...(useMvvm === 'Yes' ? { extraArgs: '-mvvm' } : {}),
+        };
     }
 
     /**
@@ -189,7 +331,11 @@ export class TemplateManager {
             cancellable: false
         }, async () => {
             try {
-                await this.executeCommand(`dotnet new winuilib -n ${libraryName}`, targetDir);
+                const source = await this.resolveTemplateSource();
+                const template = source === 'official'
+                    ? TEMPLATE_NAMES.OFFICIAL.LIBRARY
+                    : TEMPLATE_NAMES.COMMUNITY.LIBRARY;
+                await this.executeCommand(`dotnet new ${template} -n ${libraryName}`, targetDir);
                 vscode.window.showInformationMessage(`WinUI library '${libraryName}' created successfully.`);
             } catch (error) {
                 vscode.window.showErrorMessage(`Failed to create library: ${error}`);

--- a/src/winAppCli.ts
+++ b/src/winAppCli.ts
@@ -668,45 +668,46 @@ export class WinAppCli {
     /**
      * Run an application as a packaged app (v0.3.0+)
      * Registers a loose package, launches the app, and preserves LocalState across re-deploys.
+     *
+     * Throws when the underlying CLI invocation fails so callers (e.g. the
+     * `winapp` debug provider) can short-circuit follow-up steps such as
+     * debugger attach. Callers are expected to surface a user-facing error.
+     *
      * @param options Run options
      * @param cwd Optional working directory for the command
      */
     public async run(options: RunOptions, cwd?: string): Promise<void> {
-        try {
-            const inputFolder = options.inputFolder.trim();
-            if (!inputFolder) {
-                throw new Error('An input folder is required to run a packaged app.');
-            }
-
-            const args: string[] = [inputFolder];
-            if (options.manifest) {
-                args.push('--manifest', options.manifest);
-            }
-            if (options.detach) {
-                args.push('--detach');
-            }
-            if (options.unregisterOnExit) {
-                args.push('--unregister-on-exit');
-            }
-            if (options.debugOutput) {
-                args.push('--debug-output');
-            }
-            if (options.symbols) {
-                args.push('--symbols');
-            }
-            if (options.outputAppxDirectory) {
-                args.push('--output', options.outputAppxDirectory);
-            }
-            // v0.3.1+: pass application arguments after `--` so the CLI forwards them
-            // verbatim to the launched app without requiring quote escaping.
-            if (options.appArgs && options.appArgs.length > 0) {
-                args.push('--', ...options.appArgs);
-            }
-            await this.execute('run', args, cwd);
-            vscode.window.showInformationMessage('Packaged app launched successfully.');
-        } catch (error) {
-            vscode.window.showErrorMessage(`Failed to run packaged app: ${error}`);
+        const inputFolder = options.inputFolder.trim();
+        if (!inputFolder) {
+            throw new Error('An input folder is required to run a packaged app.');
         }
+
+        const args: string[] = [inputFolder];
+        if (options.manifest) {
+            args.push('--manifest', options.manifest);
+        }
+        if (options.detach) {
+            args.push('--detach');
+        }
+        if (options.unregisterOnExit) {
+            args.push('--unregister-on-exit');
+        }
+        if (options.debugOutput) {
+            args.push('--debug-output');
+        }
+        if (options.symbols) {
+            args.push('--symbols');
+        }
+        if (options.outputAppxDirectory) {
+            args.push('--output', options.outputAppxDirectory);
+        }
+        // v0.3.1+: pass application arguments after `--` so the CLI forwards them
+        // verbatim to the launched app without requiring quote escaping.
+        if (options.appArgs && options.appArgs.length > 0) {
+            args.push('--', ...options.appArgs);
+        }
+        await this.execute('run', args, cwd);
+        vscode.window.showInformationMessage('Packaged app launched successfully.');
     }
 
     /**

--- a/src/winAppCli.ts
+++ b/src/winAppCli.ts
@@ -694,6 +694,9 @@ export class WinAppCli {
             if (options.symbols) {
                 args.push('--symbols');
             }
+            if (options.outputAppxDirectory) {
+                args.push('--output', options.outputAppxDirectory);
+            }
             // v0.3.1+: pass application arguments after `--` so the CLI forwards them
             // verbatim to the launched app without requiring quote escaping.
             if (options.appArgs && options.appArgs.length > 0) {
@@ -746,6 +749,27 @@ export class WinAppCli {
             vscode.window.showInformationMessage(`App execution alias '${alias}' added to manifest.`);
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to add alias: ${error}`);
+        }
+    }
+
+    /**
+     * Generate all required app icon assets from a single source image (v0.2.1+).
+     * Wraps `winapp manifest update-assets <image>`. Accepts PNG, JPG, GIF, BMP,
+     * or SVG sources.
+     * @param imagePath Path to the source image
+     * @param manifestPath Optional path to the manifest file
+     * @param cwd Optional working directory for the command
+     */
+    public async manifestUpdateAssets(imagePath: string, manifestPath?: string, cwd?: string): Promise<void> {
+        try {
+            const args: string[] = ['update-assets', imagePath];
+            if (manifestPath) {
+                args.push('--manifest', manifestPath);
+            }
+            await this.execute('manifest', args, cwd);
+            vscode.window.showInformationMessage('Manifest assets updated successfully.');
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to update manifest assets: ${error}`);
         }
     }
 
@@ -885,6 +909,11 @@ export interface RunOptions {
     unregisterOnExit?: boolean;
     debugOutput?: boolean;
     symbols?: boolean;
+    /**
+     * Output directory for the loose-layout package produced by
+     * `winapp run`. Defaults to an `AppX` folder inside `inputFolder`.
+     */
+    outputAppxDirectory?: string;
     /**
      * Application arguments forwarded to the launched app via `--` (v0.3.1+).
      * Each entry is passed as a separate argv element, no shell escaping required.

--- a/src/winAppDebugProvider.ts
+++ b/src/winAppDebugProvider.ts
@@ -1,0 +1,421 @@
+// WinDev Helper - WinApp Debug Configuration Provider
+// Copyright (c) WinDev Helper Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as cp from 'child_process';
+import { WinAppCli } from './winAppCli';
+import { DEBUG_TYPES, OUTPUT_CHANNELS } from './constants';
+
+/**
+ * Shape of a `winapp` launch configuration. Mirrors the configuration
+ * properties exposed by the official Microsoft WinApp VS Code extension.
+ */
+interface WinAppDebugConfiguration extends vscode.DebugConfiguration {
+    type: 'winapp';
+    request: 'launch';
+    /** Build output folder containing the app's `.exe`. */
+    inputFolder?: string;
+    /** Path to the AppxManifest.xml. Auto-detected when omitted. */
+    manifest?: string;
+    /** Underlying debugger to use. */
+    debuggerType?: 'coreclr' | 'cppvsdbg' | 'node';
+    /** Working directory for the launched application. */
+    workingDirectory?: string;
+    /** Arguments forwarded to the launched application. */
+    args?: string | string[];
+    /** Output directory for the loose-layout package. */
+    outputAppxDirectory?: string;
+}
+
+/**
+ * Provides resolution and launch handling for the `winapp` debug type.
+ *
+ * Flow on F5:
+ *   1. Resolve / prompt for the build output folder.
+ *   2. Locate the application executable inside that folder.
+ *   3. Launch via `winapp run --detach` so the app starts with package
+ *      identity but our debug session keeps control.
+ *   4. Start a child debug session that attaches the requested debugger
+ *      (coreclr / cppvsdbg / node) to the running process.
+ */
+export class WinAppDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+    /** Executables that can appear in build output but are never the app itself. */
+    private static readonly EXE_BLOCKLIST = new Set<string>([
+        'createdump.exe',
+        'apphost.exe',
+        'singlefilehost.exe',
+    ]);
+
+    private readonly winAppCli: WinAppCli;
+    private readonly outputChannel: vscode.OutputChannel;
+
+    constructor(winAppCli: WinAppCli) {
+        this.winAppCli = winAppCli;
+        this.outputChannel = vscode.window.createOutputChannel(OUTPUT_CHANNELS.WINAPP_DEBUG);
+    }
+
+    /**
+     * Provides the initial `winapp` configuration shown when a user has no
+     * launch.json yet and selects the WinApp debugger.
+     */
+    public provideDebugConfigurations(
+        _folder: vscode.WorkspaceFolder | undefined,
+        _token?: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.DebugConfiguration[]> {
+        return [
+            {
+                type: DEBUG_TYPES.WINAPP,
+                request: 'launch',
+                name: 'WinApp: Launch and Attach',
+            },
+        ];
+    }
+
+    /**
+     * Fills in defaults when an empty config is supplied (e.g. via the F5
+     * prompt before any launch.json exists). Detailed work is deferred to
+     * `resolveDebugConfigurationWithSubstitutedVariables` so the user's
+     * `${workspaceFolder}` style tokens are already expanded.
+     */
+    public resolveDebugConfiguration(
+        _folder: vscode.WorkspaceFolder | undefined,
+        config: vscode.DebugConfiguration,
+        _token?: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.DebugConfiguration> {
+        if (!config.type && !config.request && !config.name) {
+            config.type = DEBUG_TYPES.WINAPP;
+            config.request = 'launch';
+            config.name = 'WinApp: Launch and Attach';
+        }
+        return config;
+    }
+
+    /**
+     * Performs the actual launch + attach. Returning `undefined` cancels the
+     * top-level debug session, which is what we want once the child session
+     * has been started successfully (the user only sees the child).
+     */
+    public async resolveDebugConfigurationWithSubstitutedVariables(
+        folder: vscode.WorkspaceFolder | undefined,
+        config: vscode.DebugConfiguration,
+        _token?: vscode.CancellationToken
+    ): Promise<vscode.DebugConfiguration | undefined | null> {
+        if (config.type !== DEBUG_TYPES.WINAPP) {
+            return config;
+        }
+
+        const winAppConfig = config as WinAppDebugConfiguration;
+        const workspaceFolder = folder ?? vscode.workspace.workspaceFolders?.[0];
+
+        const inputFolder = await this.resolveInputFolder(winAppConfig, workspaceFolder);
+        if (!inputFolder) {
+            return undefined;
+        }
+
+        const exePath = this.findAppExecutable(inputFolder, winAppConfig.manifest);
+        if (!exePath) {
+            vscode.window.showErrorMessage(
+                `No application .exe found under '${inputFolder}'. Build the project first or set 'inputFolder' in launch.json.`
+            );
+            return undefined;
+        }
+
+        this.outputChannel.appendLine(`Launching ${exePath} with package identity via 'winapp run'.`);
+        this.outputChannel.show(true);
+
+        try {
+            await this.winAppCli.run({
+                inputFolder,
+                ...(winAppConfig.manifest ? { manifest: winAppConfig.manifest } : {}),
+                ...(winAppConfig.outputAppxDirectory ? { outputAppxDirectory: winAppConfig.outputAppxDirectory } : {}),
+                detach: true,
+                ...(this.normalizeArgs(winAppConfig.args).length > 0
+                    ? { appArgs: this.normalizeArgs(winAppConfig.args) }
+                    : {}),
+            }, workspaceFolder?.uri.fsPath);
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to launch app via winapp run: ${error}`);
+            return undefined;
+        }
+
+        const debuggerType = winAppConfig.debuggerType ?? 'coreclr';
+        const exeName = path.basename(exePath);
+        const childConfig = await this.buildChildAttachConfig(
+            debuggerType,
+            exeName,
+            inputFolder,
+            winAppConfig
+        );
+
+        if (!childConfig) {
+            // We launched the app but cannot attach a debugger — keep the
+            // user informed instead of silently exiting the session.
+            vscode.window.showWarningMessage(
+                `App launched, but no PID could be resolved for '${exeName}'. Install the matching debugger extension and try again.`
+            );
+            return undefined;
+        }
+
+        const started = await vscode.debug.startDebugging(workspaceFolder, childConfig);
+        if (!started) {
+            vscode.window.showErrorMessage(
+                `App launched, but the '${debuggerType}' debugger failed to attach. Verify the debugger extension is installed.`
+            );
+        }
+
+        // Returning undefined ends the top-level winapp session; only the
+        // child attach session remains visible in the Debug view.
+        return undefined;
+    }
+
+    /**
+     * Returns the build output folder configured in launch.json or prompts
+     * the user to pick one. Auto-detects when there is exactly one candidate
+     * folder containing an `.exe` under the workspace.
+     */
+    private async resolveInputFolder(
+        config: WinAppDebugConfiguration,
+        workspaceFolder: vscode.WorkspaceFolder | undefined
+    ): Promise<string | undefined> {
+        if (config.inputFolder) {
+            const resolved = path.isAbsolute(config.inputFolder)
+                ? config.inputFolder
+                : path.join(workspaceFolder?.uri.fsPath ?? '', config.inputFolder);
+            if (fs.existsSync(resolved)) {
+                return resolved;
+            }
+            vscode.window.showWarningMessage(
+                `Configured inputFolder '${resolved}' does not exist; prompting for a folder instead.`
+            );
+        }
+
+        if (workspaceFolder) {
+            const candidates = this.discoverBuildOutputFolders(workspaceFolder.uri.fsPath);
+            if (candidates.length === 1) {
+                return candidates[0];
+            }
+            if (candidates.length > 1) {
+                const pick = await vscode.window.showQuickPick(
+                    candidates.map(c => ({
+                        label: path.relative(workspaceFolder.uri.fsPath, c) || c,
+                        description: c,
+                        value: c,
+                    })),
+                    { placeHolder: 'Select the build output folder containing your .exe' }
+                );
+                return pick?.value;
+            }
+        }
+
+        const picked = await vscode.window.showOpenDialog({
+            canSelectFolders: true,
+            canSelectFiles: false,
+            canSelectMany: false,
+            openLabel: 'Select build output folder',
+            title: 'Select the folder containing your built app',
+            ...(workspaceFolder ? { defaultUri: workspaceFolder.uri } : {}),
+        });
+        return picked?.[0]?.fsPath;
+    }
+
+    /**
+     * Walks the workspace looking for folders that directly contain a
+     * non-blocklisted `.exe`. Skips common noise (node_modules, .git, etc.)
+     * and caps recursion depth so initialization stays cheap.
+     */
+    private discoverBuildOutputFolders(root: string): string[] {
+        const skip = new Set<string>(['node_modules', '.git', '.vs', '.vscode', '.winapp', 'obj', 'packages']);
+        const found: string[] = [];
+
+        const walk = (dir: string, depth: number): void => {
+            if (depth > 8) { return; }
+
+            let entries: fs.Dirent[];
+            try {
+                entries = fs.readdirSync(dir, { withFileTypes: true });
+            } catch {
+                return;
+            }
+
+            const hasAppExe = entries.some(e =>
+                e.isFile() &&
+                e.name.toLowerCase().endsWith('.exe') &&
+                !WinAppDebugConfigurationProvider.EXE_BLOCKLIST.has(e.name.toLowerCase())
+            );
+            if (hasAppExe) {
+                found.push(dir);
+            }
+
+            for (const entry of entries) {
+                if (entry.isDirectory() && !skip.has(entry.name)) {
+                    walk(path.join(dir, entry.name), depth + 1);
+                }
+            }
+        };
+
+        walk(root, 0);
+        return found;
+    }
+
+    /**
+     * Picks the most likely application executable inside `inputFolder`.
+     * If a manifest is supplied, prefer the executable referenced by it.
+     */
+    private findAppExecutable(inputFolder: string, manifestPath?: string): string | undefined {
+        const exes = this.listAppExecutables(inputFolder);
+        if (exes.length === 0) {
+            return undefined;
+        }
+
+        const manifestExe = manifestPath ? this.readExecutableFromManifest(manifestPath) : undefined;
+        if (manifestExe) {
+            const match = exes.find(e => path.basename(e).toLowerCase() === manifestExe.toLowerCase());
+            if (match) {
+                return match;
+            }
+        }
+
+        return exes[0];
+    }
+
+    /**
+     * Lists candidate application executables in a folder, excluding
+     * known runtime helpers (createdump, apphost, etc.).
+     */
+    private listAppExecutables(folder: string): string[] {
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(folder, { withFileTypes: true });
+        } catch {
+            return [];
+        }
+        return entries
+            .filter(e =>
+                e.isFile() &&
+                e.name.toLowerCase().endsWith('.exe') &&
+                !WinAppDebugConfigurationProvider.EXE_BLOCKLIST.has(e.name.toLowerCase())
+            )
+            .map(e => path.join(folder, e.name));
+    }
+
+    /**
+     * Best-effort regex parse of `<Application ... Executable="..."/>` from
+     * an AppxManifest.xml. Returns `undefined` if the file cannot be read or
+     * the attribute is missing — full XML parsing isn't worth the dependency.
+     */
+    private readExecutableFromManifest(manifestPath: string): string | undefined {
+        try {
+            const content = fs.readFileSync(manifestPath, 'utf-8');
+            const match = content.match(/<Application[^>]*\bExecutable\s*=\s*"([^"]+)"/i);
+            if (match) {
+                return path.basename(match[1]);
+            }
+        } catch {
+            // ignore
+        }
+        return undefined;
+    }
+
+    /**
+     * Returns a child attach configuration for the requested debugger.
+     * For `coreclr` we use `processName` (most reliable post-launch).
+     * For `cppvsdbg` and `node` we resolve the PID by polling `tasklist`
+     * because those debuggers don't accept process names.
+     */
+    private async buildChildAttachConfig(
+        debuggerType: 'coreclr' | 'cppvsdbg' | 'node',
+        exeName: string,
+        inputFolder: string,
+        config: WinAppDebugConfiguration
+    ): Promise<vscode.DebugConfiguration | undefined> {
+        const sessionName = `WinApp: Attach (${exeName})`;
+        const cwd = config.workingDirectory || inputFolder;
+
+        if (debuggerType === 'coreclr') {
+            return {
+                type: 'coreclr',
+                request: 'attach',
+                name: sessionName,
+                processName: exeName,
+                cwd,
+            };
+        }
+
+        const pid = await this.waitForProcessId(exeName);
+        if (!pid) {
+            return undefined;
+        }
+
+        if (debuggerType === 'cppvsdbg') {
+            return {
+                type: 'cppvsdbg',
+                request: 'attach',
+                name: sessionName,
+                processId: pid,
+            };
+        }
+
+        // node
+        return {
+            type: 'pwa-node',
+            request: 'attach',
+            name: sessionName,
+            processId: String(pid),
+        };
+    }
+
+    /**
+     * Polls `tasklist` for up to ~10 seconds waiting for the launched app
+     * to appear, then returns its PID.
+     */
+    private async waitForProcessId(exeName: string): Promise<number | undefined> {
+        const deadline = Date.now() + 10_000;
+        while (Date.now() < deadline) {
+            const pid = this.queryProcessId(exeName);
+            if (pid) {
+                return pid;
+            }
+            await new Promise(resolve => setTimeout(resolve, 250));
+        }
+        return undefined;
+    }
+
+    /**
+     * Synchronously asks Windows for the PID of the given image name. Returns
+     * `undefined` on any failure or when the process is not yet running.
+     */
+    private queryProcessId(exeName: string): number | undefined {
+        try {
+            const output = cp.execSync(`tasklist /FI "IMAGENAME eq ${exeName}" /NH /FO CSV`, {
+                windowsHide: true,
+                encoding: 'utf-8',
+            });
+            // Lines look like: "AppName.exe","12345","Console","1","12,345 K"
+            const match = output.match(/"[^"]+","(\d+)"/);
+            if (match) {
+                return parseInt(match[1], 10);
+            }
+        } catch {
+            // tasklist returns non-zero when no matching process exists
+        }
+        return undefined;
+    }
+
+    /**
+     * Coerces the `args` configuration option into a string array. Accepts
+     * either a string (which is forwarded as-is) or a pre-split array.
+     */
+    private normalizeArgs(value: string | string[] | undefined): string[] {
+        if (!value) { return []; }
+        if (Array.isArray(value)) { return value; }
+        const trimmed = value.trim();
+        return trimmed ? [trimmed] : [];
+    }
+
+    public dispose(): void {
+        this.outputChannel.dispose();
+    }
+}


### PR DESCRIPTION
### Added

- **`winapp` debug type** (parity with the official Microsoft WinApp VS Code extension)
  - New custom debug type that launches the build output via `winapp run` (so the app gets package identity) and then attaches the requested debugger
  - Supports `coreclr` (default, C# / .NET via C# Dev Kit), `cppvsdbg` (C / C++), and `node` (Node.js / Electron) child debuggers
  - Configuration properties: `inputFolder`, `manifest`, `debuggerType`, `workingDirectory`, `args`, `outputAppxDirectory`
  - Auto-detects the build output folder by scanning for `.exe` files (skips `createdump.exe`, `apphost.exe`, and `singlefilehost.exe`)
  - Includes an initial configuration so picking *WinApp* from the F5 picker works without an existing `launch.json`

- **WinDev: Configure WinApp Debug & Tasks**
  - Scaffolds `.vscode/launch.json` and `.vscode/tasks.json` with the recommended `winapp` configuration plus a matching `preLaunchTask` (build) — based on the sample shown in [Chiara Mooney's announcement post](https://devblogs.microsoft.com/ifdef-windows/announcing-the-winapp-vs-code-extension-run-debug-and-package-windows-apps-in-vs-code/)
  - Prompts for project type (.NET, C/C++, Node.js/Electron, or Other) and emits the appropriate build task
  - Merges into existing files without overwriting unrelated entries

- **WinDev: Update Manifest Assets** (winapp CLI v0.2.1+)
  - Wraps `winapp manifest update-assets` to auto-generate all required app icon sizes from a single source image (PNG, JPG, GIF, BMP, or SVG)

- **WinDev: Run SDK Tool**
  - Provides direct access to `makeappx`, `signtool`, `mt`, and `makepri` via `winapp tool`, with custom argument tokenization

- **WinDev: Get WinApp Path**
  - Surfaces the paths reported by `winapp get-winapp-path` in the WinUI Packaging output channel

- **Support for the official Microsoft WinUI templates** ([Microsoft.WindowsAppSDK.WinUI.CSharp.Templates](https://www.nuget.org/packages/Microsoft.WindowsAppSDK.WinUI.CSharp.Templates))
  - The package is currently in alpha. **WinDev: Install WinUI Templates** now lets you choose between the official Microsoft pack and the existing community pack
  - **WinDev: Create WinUI Project** offers the official `winui`, `winui-mvvm`, `winui-navview`, and `winui-unittest` variants when the official pack is selected
  - **WinDev: Create WinUI Library** uses `winui-lib` (official) or `winuilib` (community) automatically
  - New `windevHelper.templates.source` setting (`auto`, `official`, `community`) controls the preference; `auto` prefers the official pack when installed and falls back to the community pack
  - New `windevHelper.templates.allowPrerelease` setting installs the alpha (`*-*`) version of the official pack until a stable release ships

### Changed

- **`winapp run`** now accepts an `outputAppxDirectory` option (mirrors `--output`) so the loose-layout package can be redirected when needed by the new debug type