### PR TITLE
Updates for 3.0 prod release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,30 @@ All notable changes to the WinDev Helper extension will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.10.0] - 2026-05-05
+## [3.0.0] - 2026-05-13
 
-> ⚠️ The preview pane and properties panel features are currently in preview. Please report any bugs or suggestions to our GitHub issues.
+WinDev Helper returns to **production-ready** status with this release. The `preview` flag was originally set on the 2.x line while the experimental Native XAML Preview pane and XAML Properties Pane features were under active development; both have stabilized enough to drop the release-wide preview label. The `preview` flag has been removed from the extension manifest and preview-release callouts have been retired across the docs. The Native XAML Preview pane and XAML Properties Pane remain individually labeled as preview while they continue to mature.
+
+This release also picks up the [new official `dotnet new` templates for WinUI](https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/) (PR [microsoft/WindowsAppSDK#6407](https://github.com/microsoft/WindowsAppSDK/pull/6407)) and adds a one-click setup helper for the new [WinUI agent plugin](https://devblogs.microsoft.com/ifdef-windows/build-native-windows-apps-with-ai-agents-for-winui-and-windows-app-sdk/) for the GitHub Copilot CLI and Claude Code.
+
+### Added
+
+- **TabView project template** - The `winui-tabview` template from the official Microsoft pack is now offered alongside Blank, NavigationView, MVVM, and Unit Test variants in **WinDev: Create WinUI Project**
+- **WinDev: Add New Content Dialog** - Scaffolds a `ContentDialog` via the official `winui-dialog` item template
+- **WinDev: Add New Templated Control** - Scaffolds a custom (templated) control with its `Themes/Generic.xaml` entry via the official `winui-templatedcontrol` item template
+- **WinDev: Add New Resource Dictionary** - Scaffolds a `ResourceDictionary` XAML file via the official `winui-resourcedictionary` item template
+- **WinDev: Install WinUI Copilot Plugin** - Helper that opens the GitHub Copilot CLI in a new terminal and copies the `/plugin install winui@awesome-copilot` slash-command to the clipboard so it can be pasted at the prompt. Also offers Copy Commands and Open Docs options
+- New explorer and Solution Explorer context-menu entries for the dialog, templated control, and resource dictionary item templates
+
+### Changed
+
+- **Removed `preview: true` flag from `package.json`** - The extension is no longer marked as a preview release on the Marketplace
+- **Removed preview-release banner** from the main README and from the documentation index
+- **Updated template-package descriptions** to drop "currently in alpha" references now that the official Microsoft pack has stabilized
+- **README/docs guidance** now recommends `dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates` (no `::*-*` prerelease suffix required) and showcases the new `winui-navview` / `winui-tabview` / `winui-mvvm` short names
+- All scaffolded projects now reference `Microsoft.Windows.SDK.BuildTools.WinApp` so `dotnet run` Just Works for packaged apps without manual `Add-AppxPackage` steps - documented in the README
+
+## [2.10.0] - 2026-05-05
 
 This release brings WinDev Helper closer to feature parity with the official [Microsoft WinApp VS Code extension](https://marketplace.visualstudio.com/items?itemName=Microsoft-WinAppCLI.winapp) and adds support for the new official Microsoft Windows App SDK templates.
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,12 @@
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/alvinashcraft.windev-helper)](https://marketplace.visualstudio.com/items?itemName=alvinashcraft.windev-helper)
 [![Open VSX Version](https://img.shields.io/open-vsx/v/alvinashcraft/windev-helper)](https://open-vsx.org/extension/alvinashcraft/windev-helper)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Preview](https://img.shields.io/badge/status-preview-orange)](https://marketplace.visualstudio.com/items?itemName=alvinashcraft.windev-helper)
 
 The **WinDev Helper** extension gives you the tools you need to build beautiful, performant, native Windows apps with WinUI 3 and the Windows App SDK. Built on top of the open-source C# extension (with optional [C# Dev Kit](https://aka.ms/vs/csdevkit/license) integration), it streamlines your .NET development with package management, MSIX packaging, debugging, manifest tooling, and more.
 
 The extension is published to both the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=alvinashcraft.windev-helper) and the [Open VSX Registry](https://open-vsx.org/extension/alvinashcraft/windev-helper), so it works in VS Code, [VSCodium](https://vscodium.com/), [Cursor](https://cursor.com/), [Windsurf](https://codeium.com/windsurf), and other compatible editors.
 
 This extension leverages **winapp**, the Windows App Development CLI, to provide a seamless development experience for WinUI apps in VS Code.
-
-> ⚠️ **Preview Release**: The XAML preview pane and properties panel features in version 2.x are currently in preview. Please report any bugs or suggestions to our GitHub issues.
 
 ![WinDev Helper Extension](images/icon.png)
 
@@ -86,11 +83,17 @@ On non-Windows platforms, the extension provides an HTML-based preview renderer 
 
 ### 📝 Project & Item Templates
 
-- Create new WinUI 3 projects with optional MVVM support
+- Create new WinUI 3 projects: **Blank**, **NavigationView**, **TabView**, **MVVM**, and **Unit Test** variants when using the official Microsoft template pack
 - Create WinUI class libraries
-- Add new Pages, Windows, and User Controls to your project
+- Add new **Pages**, **Windows**, **User Controls**, **Content Dialogs**, **Templated Controls**, and **Resource Dictionaries** to your project
 - **Automatic MVVM setup** - Global usings for CommunityToolkit.Mvvm are automatically added when creating views
-- Supports both the [official Microsoft Windows App SDK templates](https://www.nuget.org/packages/Microsoft.WindowsAppSDK.WinUI.CSharp.Templates) (currently in alpha) and the [community WinUI Templates](https://github.com/egvijayanand/winui-templates); pick a preference via `windevHelper.templates.source`
+- All scaffolded projects support `dotnet run` out of the box for packaged apps via the bundled `Microsoft.Windows.SDK.BuildTools.WinApp` reference
+- Supports both the [official Microsoft Windows App SDK templates](https://www.nuget.org/packages/Microsoft.WindowsAppSDK.WinUI.CSharp.Templates) and the [community WinUI Templates](https://github.com/egvijayanand/winui-templates); pick a preference via `windevHelper.templates.source`
+
+### 🤖 WinUI Copilot Plugin
+
+- **Install WinUI Copilot Plugin** - One-click helper to set up the [WinUI agent plugin](https://devblogs.microsoft.com/ifdef-windows/build-native-windows-apps-with-ai-agents-for-winui-and-windows-app-sdk/) for the GitHub Copilot CLI and Claude Code
+- Pairs naturally with this extension: the agent scaffolds and iterates on your WinUI app while VS Code handles building, debugging, packaging, and signing
 
 ### 🛠️ App Manifest Management
 
@@ -123,7 +126,7 @@ This extension requires the following VS Code extension:
 - **Windows App SDK** - Automatically referenced in WinUI projects
 - **Windows App Development CLI (winapp)** - [Learn more](https://github.com/microsoft/WinAppCli)
 - **WinUI Templates** - Install with `WinUI: Install WinUI Templates`, or directly:
-  - Official (alpha): `dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates::*-*`
+  - Official: `dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates`
   - Community: `dotnet new install VijayAnand.WinUITemplates`
 
 ### System Requirements
@@ -141,7 +144,7 @@ This extension requires the following VS Code extension:
 winget install Microsoft.DotNet.SDK.8
 
 # Install WinUI Templates (pick one)
-dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates::*-*
+dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates
 # or the community pack
 dotnet new install VijayAnand.WinUITemplates
 
@@ -163,11 +166,17 @@ Or use the command line:
 # Create a basic WinUI app
 dotnet new winui -n MyApp
 
+# Create a NavigationView app
+dotnet new winui-navview -n MyApp
+
+# Create a TabView app
+dotnet new winui-tabview -n MyApp
+
 # Create a WinUI app with MVVM
-dotnet new winui -n MyApp -mvvm
+dotnet new winui-mvvm -n MyApp
 
 # Create a WinUI library
-dotnet new winuilib -n MyLib
+dotnet new winui-lib -n MyLib
 ```
 
 ### 3. Open and Build
@@ -185,6 +194,9 @@ dotnet new winuilib -n MyLib
 | `WinUI: Add New Page` | Add a new XAML page to your project |
 | `WinUI: Add New User Control` | Add a new user control |
 | `WinUI: Add New Window` | Add a new window |
+| `WinUI: Add New Content Dialog` | Add a new ContentDialog |
+| `WinUI: Add New Templated Control` | Add a new templated (custom) control |
+| `WinUI: Add New Resource Dictionary` | Add a new ResourceDictionary XAML file |
 | `WinUI: Open XAML Preview` | Open native XAML preview panel (Preview) |
 | `WinDev: Refresh Properties` | Refresh the XAML Properties pane |
 | `WinDev: Toggle Property Grouping` | Switch between grouped and flat property view |
@@ -207,6 +219,7 @@ dotnet new winuilib -n MyLib
 | `WinUI: Select Build Configuration` | Switch Debug/Release |
 | `WinUI: Select Target Platform` | Switch x86/x64/ARM64 |
 | `WinUI: Install WinUI Templates` | Install dotnet templates |
+| `WinUI: Install WinUI Copilot Plugin` | Install the WinUI plugin for the GitHub Copilot CLI |
 | `WinUI: Check WinApp CLI Installation` | Verify CLI is installed |
 | `WinDev: Run as Packaged App` | Launch app as a packaged app |
 | `WinDev: Unregister Dev Package` | Remove a sideloaded dev package |
@@ -237,7 +250,7 @@ This extension contributes the following settings:
 | `windevHelper.preview.height` | number | `600` | Default preview height |
 | `windevHelper.preview.updateDelay` | number | `300` | Delay (ms) before updating preview after edits |
 | `windevHelper.templates.source` | string | `auto` | Template package preference: `auto`, `official`, or `community` |
-| `windevHelper.templates.allowPrerelease` | boolean | `true` | Install prerelease versions of the official Microsoft template pack while it remains in alpha |
+| `windevHelper.templates.allowPrerelease` | boolean | `true` | Install prerelease versions of the official Microsoft template pack |
 
 ## Keyboard Shortcuts
 
@@ -312,7 +325,7 @@ MyApp/
 
 - **MSIX Packaged Apps**: Debugger attachment is not yet supported for packaged apps. They launch without a debugger; set `<WindowsPackageType>None</WindowsPackageType>` in your .csproj for full F5 debug support
 - **XAML Preview (Preview)**: Third-party controls (e.g., CommunityToolkit) are replaced with placeholder grids in the preview
-- **Properties Pane**: Metadata covers ~85 WinUI control types; third-party controls may have limited property defaults
+- **Properties Pane (Preview)**: Metadata covers ~85 WinUI control types; third-party controls may have limited property defaults
 - XAML IntelliSense and Hot Reload are planned for future releases
 - Some advanced debugging scenarios may require Visual Studio
 - XAML Preview requires Windows (the native renderer uses WinUI 3)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,6 @@
 
 Welcome to the WinDev Helper extension documentation. This folder contains detailed guides and reference materials for using the extension.
 
-> ⚠️ **Preview Release**: Documentation for version 2.8 includes experimental features like native XAML preview and XAML properties pane.
-
 ## Contents
 
 - [Getting Started](getting-started.md) - Quick start guide for new users

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,11 +13,22 @@ Creates a new WinUI 3 application project.
 **Usage:**
 
 1. Opens a dialog to enter the project name
-2. Asks whether to include MVVM Toolkit support
-3. Prompts for the target folder location
-4. Creates the project and offers to open it
+2. With the official Microsoft template pack: pick from **Blank**, **NavigationView**, **TabView**, **MVVM**, or **Unit Test**
+3. With the community pack: choose whether to include MVVM Toolkit support
+4. Prompts for the target folder location
+5. Creates the project and offers to open it
 
-**Equivalent CLI:**
+**Equivalent CLI (official pack):**
+
+```bash
+dotnet new winui          -n ProjectName
+dotnet new winui-navview  -n ProjectName
+dotnet new winui-tabview  -n ProjectName
+dotnet new winui-mvvm     -n ProjectName
+dotnet new winui-unittest -n ProjectName
+```
+
+**Equivalent CLI (community pack):**
 
 ```bash
 dotnet new winui -n ProjectName
@@ -41,6 +52,10 @@ Creates a new WinUI class library project.
 **Equivalent CLI:**
 
 ```bash
+# Official pack
+dotnet new winui-lib -n LibraryName
+
+# Community pack
 dotnet new winuilib -n LibraryName
 ```
 
@@ -110,6 +125,67 @@ Adds a new window to your project.
 ```bash
 dotnet new winui-window -n WindowName
 ```
+
+---
+
+### WinUI: Add New Content Dialog
+
+**Command ID:** `windev-helper.addDialog`
+
+Adds a new `ContentDialog` to your project. Requires the official Microsoft template pack.
+
+**Equivalent CLI:**
+
+```bash
+dotnet new winui-dialog -n DialogName
+```
+
+---
+
+### WinUI: Add New Templated Control
+
+**Command ID:** `windev-helper.addTemplatedControl`
+
+Adds a new templated (custom) control with its `Themes/Generic.xaml` style entry. Requires the official Microsoft template pack.
+
+**Equivalent CLI:**
+
+```bash
+dotnet new winui-templatedcontrol -n ControlName
+```
+
+---
+
+### WinUI: Add New Resource Dictionary
+
+**Command ID:** `windev-helper.addResourceDictionary`
+
+Adds a new `ResourceDictionary` XAML file to your project. Requires the official Microsoft template pack.
+
+**Equivalent CLI:**
+
+```bash
+dotnet new winui-resourcedictionary -n DictionaryName
+```
+
+---
+
+### WinUI: Install WinUI Copilot Plugin
+
+**Command ID:** `windev-helper.installCopilotPlugin`
+
+Helper that sets up the [WinUI agent plugin](https://devblogs.microsoft.com/ifdef-windows/build-native-windows-apps-with-ai-agents-for-winui-and-windows-app-sdk/) for the GitHub Copilot CLI and Claude Code.
+
+**Usage:**
+
+1. Run from the Command Palette
+2. Pick **Launch Copilot CLI** to open a new terminal that starts `copilot` with the install slash-command copied to your clipboard, **Copy Commands** to just copy the install + setup commands, or **Open Docs** to read the announcement post
+3. Inside the Copilot CLI prompt, paste the slash-command:
+
+   ```text
+   /plugin install winui@awesome-copilot
+   /winui-setup
+   ```
 
 ---
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -4,7 +4,12 @@ This document covers the project and item templates available through the WinDev
 
 ## Overview
 
-The extension uses the [WinUI Templates](https://github.com/egvijayanand/winui-templates) package by Vijay Anand to provide project and item templates. These templates create WinUI 3 projects and items that follow best practices.
+The extension supports two `dotnet new` template packages:
+
+- **Official:** [`Microsoft.WindowsAppSDK.WinUI.CSharp.Templates`](https://www.nuget.org/packages/Microsoft.WindowsAppSDK.WinUI.CSharp.Templates) - the official Microsoft pack introduced in [WindowsAppSDK#6407](https://github.com/microsoft/WindowsAppSDK/pull/6407). Ships Blank, NavigationView, TabView, MVVM, Library, and Unit Test project templates plus item templates for pages, windows, user controls, content dialogs, templated controls, and resource dictionaries. Projects reference `Microsoft.Windows.SDK.BuildTools.WinApp` so `dotnet run` Just Works for packaged apps.
+- **Community:** [`VijayAnand.WinUITemplates`](https://github.com/egvijayanand/winui-templates) - the long-standing community pack (uses a single `winui` template with a `-mvvm` flag and a `winuilib` library template).
+
+Pick a preference via the `windevHelper.templates.source` setting (`auto`, `official`, or `community`). `auto` prefers the official pack when installed and falls back to the community pack.
 
 ## Installing Templates
 
@@ -25,6 +30,10 @@ Using VS Code:
 Using the terminal:
 
 ```bash
+# Official Microsoft pack (recommended)
+dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates
+
+# Community pack
 dotnet new install VijayAnand.WinUITemplates
 ```
 
@@ -44,7 +53,7 @@ dotnet new list winui
 
 ## Project Templates
 
-### WinUI 3 Application
+### WinUI 3 Application (Blank)
 
 **Template:** `winui`
 
@@ -61,10 +70,40 @@ dotnet new winui -n MyApp
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-n, --name` | Project name | Required |
-| `-mvvm` | Include MVVM Toolkit | false |
+| `-mvvm` | (community pack only) Include MVVM Toolkit | false |
 | `-o, --output` | Output directory | Current directory |
 
-**With MVVM Toolkit:**
+### WinUI 3 NavigationView App
+
+**Template:** `winui-navview` *(official pack)*
+
+```bash
+dotnet new winui-navview -n MyApp
+```
+
+Starter shell built around `NavigationView` with a modern title bar and basic navigation structure.
+
+### WinUI 3 TabView App
+
+**Template:** `winui-tabview` *(official pack)*
+
+```bash
+dotnet new winui-tabview -n MyApp
+```
+
+Tab-based UI silhouette with add, remove, and drag support out of the box.
+
+### WinUI 3 MVVM App
+
+**Template:** `winui-mvvm` *(official pack)*
+
+```bash
+dotnet new winui-mvvm -n MyApp
+```
+
+Blank app pre-wired with `CommunityToolkit.Mvvm` and a working sample binding.
+
+**With MVVM Toolkit (community pack):**
 
 ```bash
 dotnet new winui -n MyApp -mvvm

--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "windev-helper",
   "displayName": "WinDev Helper",
   "description": "Build beautiful, performant WinUI apps with VS Code. Debug, build, package, and deploy Windows apps powered by the Windows App SDK.",
-  "version": "2.10.0",
+  "version": "3.0.0",
   "publisher": "alvinashcraft",
-  "preview": true,
   "icon": "images/icon.png",
   "license": "MIT",
   "repository": {
@@ -71,6 +70,21 @@
       {
         "command": "windev-helper.addWindow",
         "title": "Add New Window",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.addDialog",
+        "title": "Add New Content Dialog",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.addTemplatedControl",
+        "title": "Add New Templated Control",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.addResourceDictionary",
+        "title": "Add New Resource Dictionary",
         "category": "WinDev"
       },
       {
@@ -171,6 +185,11 @@
       {
         "command": "windev-helper.installTemplates",
         "title": "Install WinUI Templates",
+        "category": "WinDev"
+      },
+      {
+        "command": "windev-helper.installCopilotPlugin",
+        "title": "Install WinUI Copilot Plugin",
         "category": "WinDev"
       },
       {
@@ -327,9 +346,24 @@
           "group": "winui@3"
         },
         {
-          "command": "windev-helper.addViewModel",
+          "command": "windev-helper.addDialog",
           "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
           "group": "winui@4"
+        },
+        {
+          "command": "windev-helper.addTemplatedControl",
+          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
+          "group": "winui@5"
+        },
+        {
+          "command": "windev-helper.addResourceDictionary",
+          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
+          "group": "winui@6"
+        },
+        {
+          "command": "windev-helper.addViewModel",
+          "when": "explorerResourceIsFolder && resourceFilename != 'bin' && resourceFilename != 'obj'",
+          "group": "winui@7"
         }
       ],
       "view/title": [
@@ -363,9 +397,24 @@
           "group": "winui@3"
         },
         {
-          "command": "windev-helper.addViewModel",
+          "command": "windev-helper.addDialog",
           "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
           "group": "winui@4"
+        },
+        {
+          "command": "windev-helper.addTemplatedControl",
+          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
+          "group": "winui@5"
+        },
+        {
+          "command": "windev-helper.addResourceDictionary",
+          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
+          "group": "winui@6"
+        },
+        {
+          "command": "windev-helper.addViewModel",
+          "when": "csharp.solutionExplorer.itemType == 'folder' || csharp.solutionExplorer.itemType == 'project'",
+          "group": "winui@7"
         }
       ],
       "commandPalette": [
@@ -492,7 +541,7 @@
           ],
           "enumDescriptions": [
             "Prefer the official Microsoft templates if installed; otherwise fall back to the community templates.",
-            "Use the official Microsoft.WindowsAppSDK.WinUI.CSharp.Templates package (currently in alpha).",
+            "Use the official Microsoft.WindowsAppSDK.WinUI.CSharp.Templates package.",
             "Use the community VijayAnand.WinUITemplates package."
           ],
           "default": "auto",
@@ -501,7 +550,7 @@
         "windevHelper.templates.allowPrerelease": {
           "type": "boolean",
           "default": true,
-          "description": "Allow installing prerelease versions of the official Microsoft WinUI template package (the alpha is required while the package is still in preview)."
+          "description": "Allow installing prerelease versions of the official Microsoft WinUI template package."
         }
       }
     },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,6 +33,9 @@ export const COMMANDS = {
     ADD_PAGE: 'windev-helper.addPage',
     ADD_USER_CONTROL: 'windev-helper.addUserControl',
     ADD_WINDOW: 'windev-helper.addWindow',
+    ADD_DIALOG: 'windev-helper.addDialog',
+    ADD_TEMPLATED_CONTROL: 'windev-helper.addTemplatedControl',
+    ADD_RESOURCE_DICTIONARY: 'windev-helper.addResourceDictionary',
     ADD_VIEW_MODEL: 'windev-helper.addViewModel',
     BUILD_PROJECT: 'windev-helper.buildProject',
     REBUILD_PROJECT: 'windev-helper.rebuildProject',
@@ -52,6 +55,7 @@ export const COMMANDS = {
     SELECT_BUILD_CONFIGURATION: 'windev-helper.selectBuildConfiguration',
     SELECT_PLATFORM: 'windev-helper.selectPlatform',
     INSTALL_TEMPLATES: 'windev-helper.installTemplates',
+    INSTALL_COPILOT_PLUGIN: 'windev-helper.installCopilotPlugin',
     CHECK_WINAPP_CLI: 'windev-helper.checkWinAppCli',
     OPEN_XAML_PREVIEW: 'windev-helper.openXamlPreview',
     // Microsoft Store commands (via winapp store subcommand)
@@ -137,10 +141,10 @@ export const DEFAULTS = {
 /**
  * Identifiers for the supported `dotnet new` template packages.
  *
- * - `OFFICIAL`: Microsoft.WindowsAppSDK.WinUI.CSharp.Templates (alpha) ships the
- *   blank-app, MVVM, NavigationView, library, and unit-test templates plus the
- *   common item templates (page, window, user control, templated control,
- *   resource dictionary, RESW, dialog).
+ * - `OFFICIAL`: Microsoft.WindowsAppSDK.WinUI.CSharp.Templates ships the
+ *   blank-app, MVVM, NavigationView, TabView, library, and unit-test templates
+ *   plus the common item templates (page, window, user control, templated
+ *   control, resource dictionary, dialog).
  * - `COMMUNITY`: VijayAnand.WinUITemplates is the long-standing community pack
  *   that this extension has used since launch and remains the default for users
  *   who already rely on its short names (`winuilib`, `-mvvm` flag).
@@ -152,17 +156,25 @@ export const TEMPLATE_PACKAGES = {
 
 /**
  * Project template short names exposed by the supported template packages.
- * The `OFFICIAL` package adds dedicated MVVM, NavigationView, library, and
- * unit-test templates; the `COMMUNITY` package uses a single `winui` template
- * with a `-mvvm` flag and a `winuilib` library template.
+ * The `OFFICIAL` package adds dedicated MVVM, NavigationView, TabView,
+ * library, and unit-test templates; the `COMMUNITY` package uses a single
+ * `winui` template with a `-mvvm` flag and a `winuilib` library template.
  */
 export const TEMPLATE_NAMES = {
     OFFICIAL: {
         BLANK: 'winui',
         MVVM: 'winui-mvvm',
         NAVIGATION_VIEW: 'winui-navview',
+        TAB_VIEW: 'winui-tabview',
         LIBRARY: 'winui-lib',
         UNIT_TEST: 'winui-unittest',
+        // Item templates
+        PAGE: 'winui-page',
+        USER_CONTROL: 'winui-usercontrol',
+        WINDOW: 'winui-window',
+        DIALOG: 'winui-dialog',
+        TEMPLATED_CONTROL: 'winui-templatedcontrol',
+        RESOURCE_DICTIONARY: 'winui-resourcedictionary',
     },
     COMMUNITY: {
         BLANK: 'winui',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,6 +141,24 @@ function registerCommands(context: vscode.ExtensionContext): void {
     );
 
     context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.ADD_DIALOG, async (uri?: vscode.Uri) => {
+            await services.templateManager.addDialog(uri);
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.ADD_TEMPLATED_CONTROL, async (uri?: vscode.Uri) => {
+            await services.templateManager.addTemplatedControl(uri);
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.ADD_RESOURCE_DICTIONARY, async (uri?: vscode.Uri) => {
+            await services.templateManager.addResourceDictionary(uri);
+        })
+    );
+
+    context.subscriptions.push(
         vscode.commands.registerCommand(COMMANDS.ADD_VIEW_MODEL, async (uri?: vscode.Uri) => {
             await services.templateManager.addViewModel(uri);
         })
@@ -278,6 +296,12 @@ function registerCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.commands.registerCommand(COMMANDS.INSTALL_TEMPLATES, async () => {
             await services.templateManager.installTemplates();
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(COMMANDS.INSTALL_COPILOT_PLUGIN, async () => {
+            await services.templateManager.installCopilotPlugin();
         })
     );
 

--- a/src/templateManager.ts
+++ b/src/templateManager.ts
@@ -373,27 +373,65 @@ export class TemplateManager {
     }
 
     /**
-     * Adds a new ContentDialog to the project (official template only).
-     * Falls back to the user control template on the community package.
+     * Adds a new ContentDialog to the project.
+     *
+     * Only the official Microsoft template pack ships `winui-dialog`; if the
+     * user has the community pack selected, this command bails out with a
+     * message asking them to install the official pack rather than silently
+     * scaffolding the wrong artifact.
      */
     public async addDialog(uri?: vscode.Uri): Promise<void> {
+        if (!(await this.ensureOfficialPack('Add New Content Dialog', 'winui-dialog'))) { return; }
         await this.addItem(TEMPLATE_NAMES.OFFICIAL.DIALOG, 'Content Dialog', uri, { supportsViewModel: true, isControl: false });
     }
 
     /**
      * Adds a new Templated (custom) Control to the project. Generates a
      * Themes/Generic.xaml entry alongside the C# class via the official
-     * template.
+     * `winui-templatedcontrol` template. Requires the official pack.
      */
     public async addTemplatedControl(uri?: vscode.Uri): Promise<void> {
+        if (!(await this.ensureOfficialPack('Add New Templated Control', 'winui-templatedcontrol'))) { return; }
         await this.addItem(TEMPLATE_NAMES.OFFICIAL.TEMPLATED_CONTROL, 'Templated Control', uri, { supportsViewModel: false, isControl: true });
     }
 
     /**
-     * Adds a new ResourceDictionary XAML file to the project.
+     * Adds a new ResourceDictionary XAML file to the project via the official
+     * `winui-resourcedictionary` template. Requires the official pack.
      */
     public async addResourceDictionary(uri?: vscode.Uri): Promise<void> {
+        if (!(await this.ensureOfficialPack('Add New Resource Dictionary', 'winui-resourcedictionary'))) { return; }
         await this.addItem(TEMPLATE_NAMES.OFFICIAL.RESOURCE_DICTIONARY, 'Resource Dictionary', uri, { supportsViewModel: false, isControl: false });
+    }
+
+    /**
+     * Verifies the resolved template source is `official` before running an
+     * item template that only ships in the Microsoft pack. Returns `true`
+     * when the user can proceed; otherwise surfaces an actionable message
+     * (offering to install the official pack) and returns `false`.
+     */
+    private async ensureOfficialPack(itemLabel: string, templateName: string): Promise<boolean> {
+        const source = await this.resolveTemplateSource();
+        if (source === 'official') { return true; }
+
+        const action = await vscode.window.showWarningMessage(
+            `${itemLabel} requires the official Microsoft template pack (${TEMPLATE_PACKAGES.OFFICIAL}). The '${templateName}' template is not included in the community pack.`,
+            'Install Official Pack',
+            'Cancel'
+        );
+
+        if (action === 'Install Official Pack') {
+            // Temporarily force the official source so installTemplates picks it.
+            const config = vscode.workspace.getConfiguration(CONFIG.SECTION);
+            const previous = config.get<string>(CONFIG.TEMPLATES_SOURCE, 'auto');
+            try {
+                await config.update(CONFIG.TEMPLATES_SOURCE, 'official', vscode.ConfigurationTarget.Workspace);
+                await this.installTemplates();
+            } finally {
+                await config.update(CONFIG.TEMPLATES_SOURCE, previous, vscode.ConfigurationTarget.Workspace);
+            }
+        }
+        return false;
     }
 
     /**
@@ -873,18 +911,34 @@ public partial class ${viewModelName} : BaseViewModel
             return;
         }
 
-        // Launch Copilot CLI in a new terminal
+        // Launch Copilot CLI in a new terminal. Surface the next-step
+        // instructions through the WinUI Templates output channel and a
+        // notification — emitting them via shell builtins (`echo`, `printf`,
+        // `Write-Host`) would either error or render inconsistently across
+        // PowerShell, bash, zsh, and cmd. This way the experience is
+        // identical regardless of the user's default integrated shell.
         await vscode.env.clipboard.writeText(installCommand);
+
+        this.outputChannel.show(true);
+        this.outputChannel.appendLine('');
+        this.outputChannel.appendLine('=== WinUI Copilot Plugin ===');
+        this.outputChannel.appendLine('Starting GitHub Copilot CLI in a new terminal...');
+        this.outputChannel.appendLine('Once the Copilot prompt loads, paste (Ctrl+V) the install command');
+        this.outputChannel.appendLine('that was copied to your clipboard:');
+        this.outputChannel.appendLine(`    ${installCommand}`);
+        this.outputChannel.appendLine('Then run:');
+        this.outputChannel.appendLine(`    ${setupCommand}`);
+        this.outputChannel.appendLine('');
+
         const terminal = vscode.window.createTerminal({ name: 'WinUI Copilot Plugin' });
         terminal.show();
-        // Print instructions to the terminal before starting the Copilot CLI so
-        // the user knows what to do once the prompt loads.
-        terminal.sendText('Write-Host "Starting GitHub Copilot CLI..." -ForegroundColor Cyan');
-        terminal.sendText(`Write-Host "Once the prompt loads, paste (Ctrl+V) the install command which has been copied to your clipboard:" -ForegroundColor Cyan`);
-        terminal.sendText(`Write-Host "  ${installCommand}" -ForegroundColor Yellow`);
-        terminal.sendText(`Write-Host "Then run:" -ForegroundColor Cyan`);
-        terminal.sendText(`Write-Host "  ${setupCommand}" -ForegroundColor Yellow`);
+        // `copilot` resolves on PATH for both PowerShell (Windows) and POSIX
+        // shells (macOS/Linux), so this single sendText is shell-agnostic.
         terminal.sendText('copilot');
+
+        vscode.window.showInformationMessage(
+            `'${installCommand}' copied to clipboard. Paste it once the Copilot CLI prompt loads, then run '${setupCommand}'.`
+        );
     }
 
     /**

--- a/src/templateManager.ts
+++ b/src/templateManager.ts
@@ -65,7 +65,7 @@ export class TemplateManager {
      * Installs WinUI templates from the dotnet template package. Prompts the
      * user when the configured source is `auto` and neither package is
      * installed yet so they can pick between the official Microsoft package
-     * (currently in alpha) and the community package.
+     * and the community package.
      */
     public async installTemplates(): Promise<void> {
         const source = await this.pickInstallSource();
@@ -118,7 +118,7 @@ export class TemplateManager {
             [
                 {
                     label: 'Official (Microsoft.WindowsAppSDK.WinUI.CSharp.Templates)',
-                    description: 'alpha — includes winui, winui-mvvm, winui-navview, winui-lib, winui-unittest',
+                    description: 'Microsoft — winui, winui-navview, winui-tabview, winui-mvvm, winui-lib, winui-unittest',
                     value: 'official' as const,
                 },
                 {
@@ -246,14 +246,19 @@ export class TemplateManager {
                         value: { template: TEMPLATE_NAMES.OFFICIAL.BLANK },
                     },
                     {
-                        label: 'MVVM App',
-                        description: 'winui-mvvm — blank app pre-wired with CommunityToolkit.Mvvm',
-                        value: { template: TEMPLATE_NAMES.OFFICIAL.MVVM },
-                    },
-                    {
                         label: 'NavigationView App',
                         description: 'winui-navview — starter shell with NavigationView',
                         value: { template: TEMPLATE_NAMES.OFFICIAL.NAVIGATION_VIEW },
+                    },
+                    {
+                        label: 'TabView App',
+                        description: 'winui-tabview — tab-based UI with add/remove/drag support',
+                        value: { template: TEMPLATE_NAMES.OFFICIAL.TAB_VIEW },
+                    },
+                    {
+                        label: 'MVVM App',
+                        description: 'winui-mvvm — blank app pre-wired with CommunityToolkit.Mvvm',
+                        value: { template: TEMPLATE_NAMES.OFFICIAL.MVVM },
                     },
                     {
                         label: 'Unit Test Project',
@@ -350,21 +355,45 @@ export class TemplateManager {
      * Adds a new Page to the project
      */
     public async addPage(uri?: vscode.Uri): Promise<void> {
-        await this.addItem('winui-page', 'Page', uri, { supportsViewModel: true, isControl: false });
+        await this.addItem(TEMPLATE_NAMES.OFFICIAL.PAGE, 'Page', uri, { supportsViewModel: true, isControl: false });
     }
 
     /**
      * Adds a new UserControl to the project
      */
     public async addUserControl(uri?: vscode.Uri): Promise<void> {
-        await this.addItem('winui-usercontrol', 'User Control', uri, { supportsViewModel: true, isControl: true });
+        await this.addItem(TEMPLATE_NAMES.OFFICIAL.USER_CONTROL, 'User Control', uri, { supportsViewModel: true, isControl: true });
     }
 
     /**
      * Adds a new Window to the project
      */
     public async addWindow(uri?: vscode.Uri): Promise<void> {
-        await this.addItem('winui-window', 'Window', uri, { supportsViewModel: true, isControl: false });
+        await this.addItem(TEMPLATE_NAMES.OFFICIAL.WINDOW, 'Window', uri, { supportsViewModel: true, isControl: false });
+    }
+
+    /**
+     * Adds a new ContentDialog to the project (official template only).
+     * Falls back to the user control template on the community package.
+     */
+    public async addDialog(uri?: vscode.Uri): Promise<void> {
+        await this.addItem(TEMPLATE_NAMES.OFFICIAL.DIALOG, 'Content Dialog', uri, { supportsViewModel: true, isControl: false });
+    }
+
+    /**
+     * Adds a new Templated (custom) Control to the project. Generates a
+     * Themes/Generic.xaml entry alongside the C# class via the official
+     * template.
+     */
+    public async addTemplatedControl(uri?: vscode.Uri): Promise<void> {
+        await this.addItem(TEMPLATE_NAMES.OFFICIAL.TEMPLATED_CONTROL, 'Templated Control', uri, { supportsViewModel: false, isControl: true });
+    }
+
+    /**
+     * Adds a new ResourceDictionary XAML file to the project.
+     */
+    public async addResourceDictionary(uri?: vscode.Uri): Promise<void> {
+        await this.addItem(TEMPLATE_NAMES.OFFICIAL.RESOURCE_DICTIONARY, 'Resource Dictionary', uri, { supportsViewModel: false, isControl: false });
     }
 
     /**
@@ -805,6 +834,57 @@ public partial class ${viewModelName} : BaseViewModel
     }
 }
 `;
+    }
+
+    /**
+     * Helps users install the official WinUI Copilot plugin for the GitHub
+     * Copilot CLI / Claude Code. The plugin ships the `winui-dev` agent and
+     * the WinUI dev / design / packaging / UI testing skills described at
+     * https://devblogs.microsoft.com/ifdef-windows/build-native-windows-apps-with-ai-agents-for-winui-and-windows-app-sdk/
+     *
+     * The actual install is a slash command inside the Copilot CLI
+     * (`/plugin install winui@awesome-copilot`), so this command opens a
+     * terminal, starts the Copilot CLI, and copies the slash command to the
+     * clipboard so the user can paste it after the prompt loads.
+     */
+    public async installCopilotPlugin(): Promise<void> {
+        const docsUrl = 'https://devblogs.microsoft.com/ifdef-windows/build-native-windows-apps-with-ai-agents-for-winui-and-windows-app-sdk/';
+        const installCommand = '/plugin install winui@awesome-copilot';
+        const setupCommand = '/winui-setup';
+
+        const choice = await vscode.window.showInformationMessage(
+            'Install the WinUI Copilot plugin? This launches the GitHub Copilot CLI in a new terminal and copies the install slash-command to your clipboard so you can paste it at the prompt.',
+            { modal: false },
+            'Launch Copilot CLI',
+            'Copy Commands',
+            'Open Docs',
+        );
+
+        if (!choice) { return; }
+
+        if (choice === 'Open Docs') {
+            await vscode.env.openExternal(vscode.Uri.parse(docsUrl));
+            return;
+        }
+
+        if (choice === 'Copy Commands') {
+            await vscode.env.clipboard.writeText(`${installCommand}\n${setupCommand}`);
+            vscode.window.showInformationMessage('Copilot plugin commands copied to clipboard. Paste them inside the Copilot CLI prompt.');
+            return;
+        }
+
+        // Launch Copilot CLI in a new terminal
+        await vscode.env.clipboard.writeText(installCommand);
+        const terminal = vscode.window.createTerminal({ name: 'WinUI Copilot Plugin' });
+        terminal.show();
+        // Print instructions to the terminal before starting the Copilot CLI so
+        // the user knows what to do once the prompt loads.
+        terminal.sendText('Write-Host "Starting GitHub Copilot CLI..." -ForegroundColor Cyan');
+        terminal.sendText(`Write-Host "Once the prompt loads, paste (Ctrl+V) the install command which has been copied to your clipboard:" -ForegroundColor Cyan`);
+        terminal.sendText(`Write-Host "  ${installCommand}" -ForegroundColor Yellow`);
+        terminal.sendText(`Write-Host "Then run:" -ForegroundColor Cyan`);
+        terminal.sendText(`Write-Host "  ${setupCommand}" -ForegroundColor Yellow`);
+        terminal.sendText('copilot');
     }
 
     /**


### PR DESCRIPTION
This release picks up the [new official `dotnet new` templates for WinUI](https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/) (PR [microsoft/WindowsAppSDK#6407](https://github.com/microsoft/WindowsAppSDK/pull/6407)) and adds a one-click setup helper for the new [WinUI agent plugin](https://devblogs.microsoft.com/ifdef-windows/build-native-windows-apps-with-ai-agents-for-winui-and-windows-app-sdk/) for the GitHub Copilot CLI and Claude Code.

### Added

- **TabView project template** - The `winui-tabview` template from the official Microsoft pack is now offered alongside Blank, NavigationView, MVVM, and Unit Test variants in **WinDev: Create WinUI Project**
- **WinDev: Add New Content Dialog** - Scaffolds a `ContentDialog` via the official `winui-dialog` item template
- **WinDev: Add New Templated Control** - Scaffolds a custom (templated) control with its `Themes/Generic.xaml` entry via the official `winui-templatedcontrol` item template
- **WinDev: Add New Resource Dictionary** - Scaffolds a `ResourceDictionary` XAML file via the official `winui-resourcedictionary` item template
- **WinDev: Install WinUI Copilot Plugin** - Helper that opens the GitHub Copilot CLI in a new terminal and copies the `/plugin install winui@awesome-copilot` slash-command to the clipboard so it can be pasted at the prompt. Also offers Copy Commands and Open Docs options
- New explorer and Solution Explorer context-menu entries for the dialog, templated control, and resource dictionary item templates

### Changed

- **Removed `preview: true` flag from `package.json`** - The extension is no longer marked as a preview release on the Marketplace
- **Removed preview-release banner** from the main README and from the documentation index
- **Updated template-package descriptions** to drop "currently in alpha" references now that the official Microsoft pack has stabilized
- **README/docs guidance** now recommends `dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates` (no `::*-*` prerelease suffix required) and showcases the new `winui-navview` / `winui-tabview` / `winui-mvvm` short names
- All scaffolded projects now reference `Microsoft.Windows.SDK.BuildTools.WinApp` so `dotnet run` Just Works for packaged apps without manual `Add-AppxPackage` steps - documented in the README