### PR TITLE
Updates for winapp CLI  v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the WinDev Helper extension will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-06-04
+
+Aligns the extension with [winapp CLI v0.3.2](https://github.com/microsoft/winappCli/releases/tag/v0.3.2).
+
+### Added
+
+- **MSIX bundle packaging** - **WinDev: Create MSIX Package** now produces an `.msixbundle` when you choose a bundle output file. It prompts for one build-output folder per architecture (e.g. `x64` and `arm64`) and passes them all to `winapp package`, which creates a bundle from multiple input folders
+- **Screenshot window focus** - **WinDev: UI: Take Screenshot** can bring the target window to the foreground before capturing, using the new `winapp ui screenshot --focus` flag. The option is offered automatically when winapp CLI v0.3.2 or newer is detected
+
+### Changed
+
+- **More resilient `winapp --version` parsing** - Version detection now skips the daily "update available" banner introduced in winapp CLI v0.3.2 so the installed version is still read correctly
+
 ## [3.1.0] - 2026-05-20
 
 This release modernizes the WinUI agent plugin setup to use the new [microsoft/win-dev-skills](https://github.com/microsoft/win-dev-skills) marketplace, adds a Windows development environment checker, and introduces light-touch support for the experimental [Microsoft.UI.Reactor](https://microsoft.github.io/microsoft-ui-reactor/) declarative C# UI framework.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -223,6 +223,17 @@ Always use a timestamp server for production:
 For multi-architecture distribution, create a bundle:
 
 ```bash
+# winapp v0.3.2+: pass one input folder per architecture to produce a bundle
+winapp package ./publish-x64 ./publish-arm64 --output ./dist/MyApp.msixbundle
+```
+
+In VS Code, run **WinDev: Create MSIX Package** and choose a `.msixbundle`
+output file. You'll be prompted to select one build-output folder per
+architecture, which are bundled together automatically.
+
+On older CLI versions you can still bundle pre-built packages manually:
+
+```bash
 # Create architecture-specific packages
 winapp package -i ./publish-x64 -o ./packages/MyApp_x64.msix
 winapp package -i ./publish-arm64 -o ./packages/MyApp_arm64.msix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windev-helper",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windev-helper",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "windev-helper",
   "displayName": "WinDev Helper",
   "description": "Build beautiful, performant WinUI apps with VS Code. Debug, build, package, and deploy Windows apps powered by the Windows App SDK.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "publisher": "alvinashcraft",
   "icon": "images/icon.png",
   "license": "MIT",

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -107,8 +107,16 @@ export class PackageManager {
                 this.outputChannel.appendLine('Publishing project...');
                 this.outputChannel.show();
 
-                // Look for the manifest
-                const manifestPath = await this.findManifest(inputDirs[0]);
+                // Look for the manifest. When bundling, the user's selection order
+                // is not guaranteed, so scan all input folders and use the first
+                // that actually contains a manifest (falling back to the first folder).
+                let manifestPath: string | undefined;
+                for (const dir of inputDirs) {
+                    manifestPath = await this.findManifest(dir);
+                    if (manifestPath) {
+                        break;
+                    }
+                }
 
                 await this.winAppCli.package({
                     inputDirs,

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -79,6 +79,24 @@ export class PackageManager {
             return;
         }
 
+        // Supplying multiple input folders (one per architecture) produces an
+        // MSIX bundle. Prompt for them when the user chose a .msixbundle output;
+        // otherwise package the single project directory.
+        let inputDirs: string[] = [projectDir];
+        if (outputUri.fsPath.toLowerCase().endsWith('.msixbundle')) {
+            const folderUris = await vscode.window.showOpenDialog({
+                canSelectFiles: false,
+                canSelectFolders: true,
+                canSelectMany: true,
+                defaultUri: vscode.Uri.file(projectDir),
+                title: 'Select build-output folders to bundle (one per architecture)'
+            });
+            if (!folderUris || folderUris.length === 0) {
+                return;
+            }
+            inputDirs = folderUris.map(u => u.fsPath);
+        }
+
         await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
             title: 'Creating MSIX package...',
@@ -90,10 +108,10 @@ export class PackageManager {
                 this.outputChannel.show();
 
                 // Look for the manifest
-                const manifestPath = await this.findManifest(projectDir);
+                const manifestPath = await this.findManifest(inputDirs[0]);
 
                 await this.winAppCli.package({
-                    inputDir: projectDir,
+                    inputDirs,
                     outputPath: outputUri.fsPath,
                     ...(manifestPath && { manifestPath })
                 });
@@ -858,6 +876,17 @@ export class PackageManager {
         });
         if (!appName) { return; }
 
+        // v0.3.2+: optionally bring the target window to the foreground first.
+        let focus = false;
+        if (await this.winAppCli.supportsScreenshotFocus()) {
+            const focusChoice = await vscode.window.showQuickPick(['Yes', 'No'], {
+                placeHolder: 'Bring the window to the foreground before capturing?',
+                title: 'Screenshot Focus'
+            });
+            if (!focusChoice) { return; }
+            focus = focusChoice === 'Yes';
+        }
+
         const workspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri;
         const saveDialogOptions: vscode.SaveDialogOptions = {
             filters: {
@@ -878,7 +907,7 @@ export class PackageManager {
             title: 'Taking screenshot...',
             cancellable: false
         }, async () => {
-            await this.winAppCli.uiScreenshot(appName, outputUri.fsPath);
+            await this.winAppCli.uiScreenshot(appName, outputUri.fsPath, focus);
         });
     }
 

--- a/src/templateManager.ts
+++ b/src/templateManager.ts
@@ -1185,7 +1185,14 @@ public partial class ${viewModelName} : BaseViewModel
     private async checkWinAppCliVersion(): Promise<{ ok: boolean; detail: string }> {
         try {
             const output = await this.executeCommand('winapp --version', undefined, true);
-            const match = /(\d+)\.(\d+)(?:\.(\d+))?/.exec(output);
+            // v0.3.2+ may prepend an "update available" banner on the first run of
+            // the day; prefer a line that is only a version string so the banner
+            // can't be mistaken for the installed version.
+            const versionLine = output
+                .split(/\r?\n/)
+                .map(l => l.trim())
+                .find(l => /^v?\d+\.\d+/.test(l));
+            const match = /(\d+)\.(\d+)(?:\.(\d+))?/.exec(versionLine ?? output);
             if (!match) {
                 return { ok: false, detail: 'could not parse `winapp --version` output' };
             }

--- a/src/templateManager.ts
+++ b/src/templateManager.ts
@@ -1191,7 +1191,7 @@ public partial class ${viewModelName} : BaseViewModel
             const versionLine = output
                 .split(/\r?\n/)
                 .map(l => l.trim())
-                .find(l => /^v?\d+\.\d+/.test(l));
+                .find(l => /^v?\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?$/.test(l));
             const match = /(\d+)\.(\d+)(?:\.(\d+))?/.exec(versionLine ?? output);
             if (!match) {
                 return { ok: false, detail: 'could not parse `winapp --version` output' };

--- a/src/winAppCli.ts
+++ b/src/winAppCli.ts
@@ -74,7 +74,15 @@ export class WinAppCli {
      * Returns `null` if the input does not match.
      */
     private parseSemver(input: string): { major: number; minor: number; patch: number } | null {
-        const match = input.match(/(\d+)\.(\d+)\.(\d+)/);
+        // `winapp --version` may emit an extra "update available" banner (v0.3.2+)
+        // on the first run of the day. Prefer a line that is *only* a version
+        // string so the banner's version can't be mistaken for the installed one;
+        // fall back to the first semver found anywhere in the output.
+        const versionLine = input
+            .split(/\r?\n/)
+            .map(l => l.trim())
+            .find(l => /^v?\d+\.\d+\.\d+/.test(l));
+        const match = (versionLine ?? input).match(/(\d+)\.(\d+)\.(\d+)/);
         if (!match) {
             return null;
         }
@@ -116,6 +124,22 @@ export class WinAppCli {
         return (v.major > 0) ||
             (v.major === 0 && v.minor > 3) ||
             (v.major === 0 && v.minor === 3 && v.patch >= 1);
+    }
+
+    /**
+     * Returns `true` when the installed winapp CLI supports the `--focus`
+     * flag on `ui screenshot` (introduced in v0.3.2). When the version cannot
+     * be determined, returns `false` so the flag is not passed to an older CLI
+     * that would reject it.
+     */
+    public async supportsScreenshotFocus(): Promise<boolean> {
+        const v = await this.getVersion();
+        if (!v) {
+            return false;
+        }
+        return (v.major > 0) ||
+            (v.major === 0 && v.minor > 3) ||
+            (v.major === 0 && v.minor === 3 && v.patch >= 2);
     }
 
     /**
@@ -357,9 +381,13 @@ export class WinAppCli {
     public async package(options: PackageOptions): Promise<void> {
         try {
             const args: string[] = [];
-            // Input folder is a positional argument (required)
-            if (options.inputDir) {
-                args.push(options.inputDir);
+            // Input folders are positional arguments (required). Supplying more
+            // than one produces an MSIX bundle (one folder per architecture).
+            const inputDirs = options.inputDirs && options.inputDirs.length > 0
+                ? options.inputDirs
+                : (options.inputDir ? [options.inputDir] : []);
+            for (const dir of inputDirs) {
+                args.push(dir);
             }
             // Use long-form options as per CLI spec
             if (options.outputPath) {
@@ -817,10 +845,16 @@ export class WinAppCli {
      * Take a screenshot of an app window (v0.3.0+)
      * @param appName App name to screenshot
      * @param outputPath Output file path for the screenshot
+     * @param focus Bring the target window to the foreground first (`--focus`, v0.3.2+)
      */
-    public async uiScreenshot(appName: string, outputPath: string): Promise<void> {
+    public async uiScreenshot(appName: string, outputPath: string, focus: boolean = false): Promise<void> {
         try {
-            await this.execute('ui', ['screenshot', '-a', appName, '-o', outputPath]);
+            const args = ['screenshot', '-a', appName, '-o', outputPath];
+            // v0.3.2+: bring the target window to the foreground before capture.
+            if (focus) {
+                args.push('--focus');
+            }
+            await this.execute('ui', args);
             vscode.window.showInformationMessage(`Screenshot saved to ${outputPath}`);
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to take screenshot: ${error}`);
@@ -851,6 +885,11 @@ export class WinAppCli {
 
 export interface PackageOptions {
     inputDir?: string;
+    /**
+     * One or more input folders. Supplying multiple folders (one per
+     * architecture) creates an MSIX bundle. Takes precedence over `inputDir`.
+     */
+    inputDirs?: string[];
     outputPath?: string;
     manifestPath?: string;
     certPath?: string;

--- a/src/winAppCli.ts
+++ b/src/winAppCli.ts
@@ -76,12 +76,13 @@ export class WinAppCli {
     private parseSemver(input: string): { major: number; minor: number; patch: number } | null {
         // `winapp --version` may emit an extra "update available" banner (v0.3.2+)
         // on the first run of the day. Prefer a line that is *only* a version
-        // string so the banner's version can't be mistaken for the installed one;
+        // string (optionally prefixed with `v` or suffixed with a prerelease tag)
+        // so the banner's version can't be mistaken for the installed one;
         // fall back to the first semver found anywhere in the output.
         const versionLine = input
             .split(/\r?\n/)
             .map(l => l.trim())
-            .find(l => /^v?\d+\.\d+\.\d+/.test(l));
+            .find(l => /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(l));
         const match = (versionLine ?? input).match(/(\d+)\.(\d+)\.(\d+)/);
         if (!match) {
             return null;


### PR DESCRIPTION
Aligns the extension with [winapp CLI v0.3.2](https://github.com/microsoft/winappCli/releases/tag/v0.3.2).

### Added

- **MSIX bundle packaging** - **WinDev: Create MSIX Package** now produces an `.msixbundle` when you choose a bundle output file. It prompts for one build-output folder per architecture (e.g. `x64` and `arm64`) and passes them all to `winapp package`, which creates a bundle from multiple input folders
- **Screenshot window focus** - **WinDev: UI: Take Screenshot** can bring the target window to the foreground before capturing, using the new `winapp ui screenshot --focus` flag. The option is offered automatically when winapp CLI v0.3.2 or newer is detected

### Changed

- **More resilient `winapp --version` parsing** - Version detection now skips the daily "update available" banner introduced in winapp CLI v0.3.2 so the installed version is still read correctly